### PR TITLE
EdDSA support for JWTs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-12-01  Kirit Saelensminde  <kirit@felspar.com>
+ Support EdDSA JWTs.
+
 2018-11-08  Kirit Saelensminde  <kirit@felspar.com>
  JWT secrets can now be looked up via a function passed to the load function.
 

--- a/Cpp/fost-crypto/ed25519.cpp
+++ b/Cpp/fost-crypto/ed25519.cpp
@@ -70,7 +70,7 @@ std::array<f5::byte, 64> fostlib::ed25519::keypair::sign(
 
 
 bool fostlib::ed25519::verify(
-        secret pub,
+        f5::buffer<const f5::byte> pub,
         f5::buffer<const f5::byte> msg,
         f5::buffer<const f5::byte> sig) {
     /// Because NaCl has a stupid API we have to build it's message format out

--- a/Cpp/fost-crypto/ed25519.cpp
+++ b/Cpp/fost-crypto/ed25519.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2018, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -44,6 +44,11 @@ fostlib::ed25519::keypair::keypair(secret sk) {
     std::copy(sk.begin(), sk.end(), privkey.begin());
     auto pk = signing_pubkey(priv());
     std::copy(pk.begin(), pk.end(), privkey.begin() + 32);
+}
+
+
+fostlib::ed25519::keypair::keypair(f5::buffer<const f5::byte> sk) {
+    std::copy(sk.begin(), sk.end(), privkey.begin());
 }
 
 

--- a/Cpp/fost-crypto/ed25519.cpp
+++ b/Cpp/fost-crypto/ed25519.cpp
@@ -48,6 +48,12 @@ fostlib::ed25519::keypair::keypair(secret sk) {
 
 
 fostlib::ed25519::keypair::keypair(f5::buffer<const f5::byte> sk) {
+    if (sk.size() != privkey.size()) {
+        throw exceptions::out_of_range(
+                "Buffer passed for Ed26619 private/public key pair must be 64 "
+                "bytes",
+                privkey.size(), privkey.size(), sk.size());
+    }
     std::copy(sk.begin(), sk.end(), privkey.begin());
 }
 

--- a/Cpp/fost-crypto/ed25519.cpp
+++ b/Cpp/fost-crypto/ed25519.cpp
@@ -52,18 +52,54 @@ fostlib::ed25519::keypair::keypair(f5::buffer<const f5::byte> sk) {
 }
 
 
-std::array<f5::byte, 64>
-        fostlib::ed25519::keypair::sign(f5::buffer<const f5::byte> data) const {
-    std::vector<f5::byte> signature(data.size() + 64);
+std::array<f5::byte, 64> fostlib::ed25519::keypair::sign(
+        f5::buffer<const f5::byte> message) const {
+    std::vector<f5::byte> signature(message.size() + 64);
     uint64_t siglen{signature.size()};
     fostlib::nacl::crypto_sign(
-            signature.data(), &siglen, data.data(), data.size(),
+            signature.data(), &siglen, message.data(), message.size(),
             privkey.data());
     if (siglen < 64)
-        throw fostlib::exceptions::not_implemented(
-                __func__, "Unexpected ed25519 signature length - too short",
-                siglen);
+        throw exceptions::not_implemented(
+                __PRETTY_FUNCTION__,
+                "Unexpected ed25519 signature length - too short", siglen);
     std::array<f5::byte, 64> ret;
     std::copy(signature.begin(), signature.begin() + 64, ret.begin());
     return ret;
+}
+
+
+bool fostlib::ed25519::verify(
+        secret pub,
+        f5::buffer<const f5::byte> msg,
+        f5::buffer<const f5::byte> sig) {
+    /// Because NaCl has a stupid API we have to build it's message format out
+    /// of the parts we have before we can do anything else
+    std::vector<f5::byte> msgsig(msg.size() + sig.size());
+    std::copy(sig.begin(), sig.end(), msgsig.begin());
+    std::copy(msg.begin(), msg.end(), msgsig.begin() + sig.size());
+    /// We also need a buffer for NaCl to give us the message back in (!) so
+    /// that we can ignore it because we actually got handed the message as a
+    /// parameter. Note that the outmsg allocation is larger than might be
+    /// expected as the NaCl documentation tells us we must allocate enough for
+    /// the message and the secret (for some reason).
+    std::vector<f5::byte> outmsg(msgsig.size());
+    uint64_t outmsg_len{};
+    if (fostlib::nacl::crypto_sign_open(
+                outmsg.data(), &outmsg_len, msgsig.data(), msgsig.size(),
+                pub.data())
+        == 0) {
+        if (outmsg_len != msg.size()) {
+            /// If this check is ever false then probably we're in  a lot of
+            /// trouble, especially if the output buffer is  now longer than the
+            /// one we allocated
+            throw exceptions::not_implemented(
+                    __PRETTY_FUNCTION__,
+                    "Something truly awful happened and the message somehow "
+                    "grew");
+        }
+        return true;
+    } else {
+        return false;
+    }
 }

--- a/Cpp/fost-crypto/ed25519.tests.cpp
+++ b/Cpp/fost-crypto/ed25519.tests.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2018, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -12,13 +12,7 @@
 #include <fost/test>
 
 
-FSL_TEST_SUITE(ed25519);
-
-
-FSL_TEST_FUNCTION(new_keys) { fostlib::ed25519::keypair keys; }
-
-
-FSL_TEST_FUNCTION(public_from_private) {
+namespace {
     const fostlib::ed25519::secret priv{
             {f5::byte(0x9d), f5::byte(0x61), f5::byte(0xb1), f5::byte(0x9d),
              f5::byte(0xef), f5::byte(0xfd), f5::byte(0x5a), f5::byte(0x60),
@@ -37,7 +31,16 @@ FSL_TEST_FUNCTION(public_from_private) {
              f5::byte(0xda), f5::byte(0xa6), f5::byte(0x23), f5::byte(0x25),
              f5::byte(0xaf), f5::byte(0x02), f5::byte(0x1a), f5::byte(0x68),
              f5::byte(0xf7), f5::byte(0x07), f5::byte(0x51), f5::byte(0x1a)}};
+}
 
+
+FSL_TEST_SUITE(ed25519);
+
+
+FSL_TEST_FUNCTION(new_keys) { fostlib::ed25519::keypair keys; }
+
+
+FSL_TEST_FUNCTION(public_from_private) {
     fostlib::ed25519::keypair keys{priv};
     try {
         FSL_CHECK(keys.pub() == pub);
@@ -50,4 +53,19 @@ FSL_TEST_FUNCTION(public_from_private) {
         }
         throw;
     }
+}
+
+
+FSL_TEST_FUNCTION(sign_jwt) {
+    /// The example data is taken from [RFC8037 Appendix
+    /// A](https://tools.ietf.org/html/rfc8037#appendix-A) part A.
+    fostlib::ed25519::keypair keys{priv};
+    const f5::u8view header_b64 = "eyJhbGciOiJFZERTQSJ9";
+    const f5::u8view payload_b64 = "RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc";
+    FSL_CHECK_EQ(
+            fostlib::jwt::sign_base64_jwt(
+                    header_b64, payload_b64, fostlib::jwt::alg::EdDSA, keys),
+            "eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_"
+            "MGCjP0JzlnLWG1PPOt7-"
+            "09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg");
 }

--- a/Cpp/fost-crypto/ed25519.tests.cpp
+++ b/Cpp/fost-crypto/ed25519.tests.cpp
@@ -40,6 +40,14 @@ FSL_TEST_SUITE(ed25519);
 FSL_TEST_FUNCTION(new_keys) { fostlib::ed25519::keypair keys; }
 
 
+FSL_TEST_FUNCTION(key_import_size_error) {
+    unsigned char b[10];
+    FSL_CHECK_EXCEPTION(
+            fostlib::ed25519::keypair k{b},
+            fostlib::exceptions::out_of_range<std::size_t> &);
+}
+
+
 FSL_TEST_FUNCTION(public_from_private) {
     fostlib::ed25519::keypair keys{priv};
     try {

--- a/Cpp/fost-crypto/ed25519.tests.cpp
+++ b/Cpp/fost-crypto/ed25519.tests.cpp
@@ -96,3 +96,32 @@ FSL_TEST_FUNCTION(sign_jwt2) {
             "Sgj-1wBoW4S_ADNugICg");
 }
 
+
+FSL_TEST_FUNCTION(load_valid_jwt) {
+    /// This JWT is the one produced in the `sign_jwt2` test as we don't have
+    /// another example that has a valid JSON body
+    auto const jwt = fostlib::jwt::token::load(
+            [](auto, auto) -> std::vector<f5::byte> {
+                return std::vector<f5::byte>(pub.begin(), pub.end());
+            },
+            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0ZXIifQ."
+            "WdTr0f9oRRfVUGPUmzMNNlACNdE8TtDGRgQltg7936tsSVOhUOeuqGYdzg1lYAH69-"
+            "Sgj-1wBoW4S_ADNugICg");
+    FSL_CHECK(jwt);
+}
+
+
+FSL_TEST_FUNCTION(load_invalid_jwt) {
+    /// This JWT is the one produced in the `sign_jwt2` test as we don't have
+    /// another example that has a valid JSON body
+    auto const jwt = fostlib::jwt::token::load(
+            [](auto, auto) -> std::vector<f5::byte> {
+                fostlib::ed25519::keypair invalid;
+                auto const pub = invalid.pub();
+                return std::vector<f5::byte>(pub.begin(), pub.end());
+            },
+            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0ZXIifQ."
+            "WdTr0f9oRRfVUGPUmzMNNlACNdE8TtDGRgQltg7936tsSVOhUOeuqGYdzg1lYAH69-"
+            "Sgj-1wBoW4S_ADNugICg");
+    FSL_CHECK(not jwt);
+}

--- a/Cpp/fost-crypto/ed25519.tests.cpp
+++ b/Cpp/fost-crypto/ed25519.tests.cpp
@@ -101,12 +101,12 @@ FSL_TEST_FUNCTION(load_valid_jwt) {
     /// This JWT is the one produced in the `sign_jwt2` test as we don't have
     /// another example that has a valid JSON body
     auto const jwt = fostlib::jwt::token::load(
-            [](auto, auto) -> std::vector<f5::byte> {
-                return std::vector<f5::byte>(pub.begin(), pub.end());
-            },
             "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0ZXIifQ."
             "WdTr0f9oRRfVUGPUmzMNNlACNdE8TtDGRgQltg7936tsSVOhUOeuqGYdzg1lYAH69-"
-            "Sgj-1wBoW4S_ADNugICg");
+            "Sgj-1wBoW4S_ADNugICg",
+            [](auto, auto) -> std::vector<f5::byte> {
+                return std::vector<f5::byte>(pub.begin(), pub.end());
+            });
     FSL_CHECK(jwt);
 }
 
@@ -115,13 +115,13 @@ FSL_TEST_FUNCTION(load_invalid_jwt) {
     /// This JWT is the one produced in the `sign_jwt2` test as we don't have
     /// another example that has a valid JSON body
     auto const jwt = fostlib::jwt::token::load(
+            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0ZXIifQ."
+            "WdTr0f9oRRfVUGPUmzMNNlACNdE8TtDGRgQltg7936tsSVOhUOeuqGYdzg1lYAH69-"
+            "Sgj-1wBoW4S_ADNugICg",
             [](auto, auto) -> std::vector<f5::byte> {
                 fostlib::ed25519::keypair invalid;
                 auto const pub = invalid.pub();
                 return std::vector<f5::byte>(pub.begin(), pub.end());
-            },
-            "eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0ZXIifQ."
-            "WdTr0f9oRRfVUGPUmzMNNlACNdE8TtDGRgQltg7936tsSVOhUOeuqGYdzg1lYAH69-"
-            "Sgj-1wBoW4S_ADNugICg");
+            });
     FSL_CHECK(not jwt);
 }

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -7,6 +7,7 @@
 
 
 #include "fost-crypto.hpp"
+#include <fost/ed25519.hpp>
 #include <fost/jwt.hpp>
 
 #include <fost/exception/parse_error.hpp>
@@ -138,7 +139,14 @@ std::string fostlib::jwt::sign_base64_jwt(
         return header_b64 + "." + payload_b64 + "."
                 + base64url(digester.digest()).underlying();
     }
-    case alg::EdDSA: throw exceptions::not_implemented(__PRETTY_FUNCTION__);
+    case alg::EdDSA: {
+        ed25519::keypair const kp{key};
+        auto const b64 = header_b64 + "." + payload_b64;
+        auto const signature = kp.sign(f5::buffer<const f5::byte>{
+                reinterpret_cast<unsigned char const *>(b64.data()),
+                b64.size()});
+        return b64 + "." + base64url(signature).underlying();
+    }
     }
 }
 

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -174,6 +174,7 @@ fostlib::nullable<fostlib::jwt::token> fostlib::jwt::token::load(
         const auto header = json::parse(str_header);
         if (header["typ"] != jwt) {
             log::warning(c_fost)("", "JWT type mismatch")("typ", header["typ"]);
+            return fostlib::null;
         }
 
         const base64_string b64_payload(parts[1].c_str());

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -157,8 +157,8 @@ std::string fostlib::jwt::sign_base64_jwt(
 
 
 fostlib::nullable<fostlib::jwt::token> fostlib::jwt::token::load(
-        const std::function<std::vector<f5::byte>(json, json)> &lambda,
-        f5::u8view t) {
+        f5::u8view t,
+        const std::function<std::vector<f5::byte>(json, json)> &lambda) {
     const auto parts = split(t, ".");
     if (parts.size() != 3u) return fostlib::null;
 

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -157,23 +157,23 @@ std::string fostlib::jwt::sign_base64_jwt(
 
 
 fostlib::nullable<fostlib::jwt::token> fostlib::jwt::token::load(
-        const std::function<string(json, json)> &lambda, f5::u8view t) {
+        const std::function<std::vector<f5::byte>(json, json)> &lambda,
+        f5::u8view t) {
     const auto parts = split(t, ".");
     if (parts.size() != 3u) return fostlib::null;
 
     try {
         const static json jwt("JWT");
         const static json hs256("HS256");
+        const static json eddsa("EdDSA");
 
         const base64_string b64_header{parts[0].c_str()};
         const auto v64_header = coerce<std::vector<unsigned char>>(b64_header);
         const auto u8_header = coerce<utf8_string>(v64_header);
         const auto str_header = coerce<string>(u8_header);
         const auto header = json::parse(str_header);
-        if (header["typ"] != jwt || header["alg"] != hs256) {
-            log::warning(c_fost)("", "JWT type or algorithm mismatch")(
-                    "typ", header["typ"])("alg", header["alg"]);
-            return fostlib::null;
+        if (header["typ"] != jwt) {
+            log::warning(c_fost)("", "JWT type mismatch")("typ", header["typ"]);
         }
 
         const base64_string b64_payload(parts[1].c_str());
@@ -186,25 +186,32 @@ fostlib::nullable<fostlib::jwt::token> fostlib::jwt::token::load(
         const base64_string b64_signature(parts[2].c_str());
         const auto v64_signature =
                 coerce<std::vector<unsigned char>>(b64_signature);
-        hmac signer(sha256, lambda(header, payload));
-        signer << parts[0] << "." << parts[1];
-        const auto signature = signer.digest();
+        if (header["alg"] == hs256) {
+            hmac signer(sha256, lambda(header, payload));
+            signer << parts[0] << "." << parts[1];
+            const auto signature = signer.digest();
 
-        if (crypto_compare(signature, v64_signature)) {
-            if (payload.has_key("exp")) {
-                auto exp = c_epoch
-                        + fostlib::timediff(fostlib::seconds(
-                                  fostlib::coerce<int64_t>(payload["exp"])));
-                if (exp < fostlib::timestamp::now()) {
-                    log::warning(c_fost)("", "JWT expired")("expires", exp);
-                    return fostlib::null;
-                }
+            if (not crypto_compare(signature, v64_signature)) {
+                log::warning(c_fost)("", "JWT signature mismatch");
+                return fostlib::null;
             }
-            return fostlib::jwt::token{header, payload};
+        } else if (header["alg"] == eddsa) {
+            throw exceptions::not_implemented(__PRETTY_FUNCTION__);
         } else {
-            log::warning(c_fost)("", "JWT signature mismatch");
+            log::warning(c_fost)("", "JWT algorithm mismatch")(
+                    "alg", header["alg"]);
             return fostlib::null;
         }
+        if (payload.has_key("exp")) {
+            auto exp = c_epoch
+                    + fostlib::timediff(fostlib::seconds(
+                              fostlib::coerce<int64_t>(payload["exp"])));
+            if (exp < fostlib::timestamp::now()) {
+                log::warning(c_fost)("", "JWT expired")("expires", exp);
+                return fostlib::null;
+            }
+        }
+        return fostlib::jwt::token{header, payload};
     } catch (fostlib::exceptions::parse_error &e) {
         log::warning(c_fost)("", "JWT parse error")("error", e);
         return fostlib::null;

--- a/Cpp/fost-crypto/jwt.cpp
+++ b/Cpp/fost-crypto/jwt.cpp
@@ -196,7 +196,12 @@ fostlib::nullable<fostlib::jwt::token> fostlib::jwt::token::load(
                 return fostlib::null;
             }
         } else if (header["alg"] == eddsa) {
-            throw exceptions::not_implemented(__PRETTY_FUNCTION__);
+            if (not fostlib::ed25519::verify(
+                        lambda(header, payload),
+                        (parts[0] + "." + parts[1]).data(), v64_signature)) {
+                log::warning(c_fost)("", "EdDSA verification failed");
+                return fostlib::null;
+            }
         } else {
             log::warning(c_fost)("", "JWT algorithm mismatch")(
                     "alg", header["alg"]);

--- a/Cpp/fost-crypto/signature.cpp
+++ b/Cpp/fost-crypto/signature.cpp
@@ -76,7 +76,7 @@ struct hmac_impl : public fostlib::hmac::impl {
 };
 
 
-fostlib::hmac::hmac(digester_fn hash, const string &key)
+fostlib::hmac::hmac(digester_fn hash, f5::buffer<const f5::byte> key)
 : m_implementation(nullptr) {
     if (hash == fostlib::sha1)
         m_implementation = std::make_unique<hmac_impl<CryptoPP::SHA1>>();
@@ -85,30 +85,10 @@ fostlib::hmac::hmac(digester_fn hash, const string &key)
     else if (hash == fostlib::md5)
         m_implementation = std::make_unique<hmac_impl<CryptoPP::Weak::MD5>>();
     else
-        throw fostlib::exceptions::not_implemented(
-                "fostlib::hmac::hmac("
-                "string (*digest_function)( const string & ), const string "
-                "&key)"
+        throw exceptions::not_implemented(
+                __PRETTY_FUNCTION__,
                 "-- Only sha1, sha256 and md5 are supported");
-    const auto utf8key = coerce<utf8_string>(key);
-    m_implementation->set_key(
-            utf8key.underlying().c_str(), utf8key.underlying().length());
-}
-fostlib::hmac::hmac(digester_fn hash, const void *key, std::size_t key_length)
-: m_implementation(nullptr) {
-    if (hash == fostlib::sha1)
-        m_implementation = std::make_unique<hmac_impl<CryptoPP::SHA1>>();
-    else if (hash == fostlib::sha256)
-        m_implementation = std::make_unique<hmac_impl<CryptoPP::SHA256>>();
-    else if (hash == fostlib::md5)
-        m_implementation = std::make_unique<hmac_impl<CryptoPP::Weak::MD5>>();
-    else
-        throw fostlib::exceptions::not_implemented(
-                "fostlib::hmac::hmac("
-                "string (*digest_function)( const string & ), const string "
-                "&key)"
-                "-- Only sha1, sha256 and md5 are supported");
-    m_implementation->set_key(key, key_length);
+    m_implementation->set_key(key.data(), key.size());
 }
 fostlib::hmac::hmac(hmac &&h)
 : m_implementation(std::move(h.m_implementation)) {}

--- a/Cpp/include/fost/crypto.hpp
+++ b/Cpp/include/fost/crypto.hpp
@@ -79,7 +79,7 @@ namespace fostlib {
 
 
     /// Generic digester for hash algorithms.
-    class FOST_CRYPTO_DECLSPEC digester : boost::noncopyable {
+    class FOST_CRYPTO_DECLSPEC digester {
       public:
         /// Construct the digester from the wanted digest function
         digester(digester_fn);
@@ -111,21 +111,24 @@ namespace fostlib {
     FOST_CRYPTO_DECLSPEC
     string sha1_hmac(const string &key, const string &data);
 
-    class FOST_CRYPTO_DECLSPEC hmac : boost::noncopyable {
+    class FOST_CRYPTO_DECLSPEC hmac {
       public:
         /// Construct a HMAC with the given digest and secret
-        hmac(digester_fn, const string &key);
-        /// Construct a HMAC with the given digest and secret
-        hmac(digester_fn, const void *key, std::size_t key_length);
-        /// Construct a HMAC with the given digest and secret
-        template<std::size_t n>
-        hmac(digester_fn digest_function, const std::array<unsigned char, n> &s)
+        hmac(digester_fn, f5::buffer<const f5::byte>);
+        hmac(digester_fn d, const string &key)
+        : hmac(d, f5::buffer<const f5::byte>{f5::u8view{key}}) {}
+        hmac(digester_fn d, const void *key, std::size_t key_length)
+        : hmac(d,
+               f5::buffer<const f5::byte>(
+                       reinterpret_cast<unsigned char const *>(key),
+                       key_length)) {}
+        template<std::size_t N>
+        hmac(digester_fn digest_function, const std::array<unsigned char, N> &s)
         : hmac(digest_function,
                reinterpret_cast<const void *>(s.data()),
                s.size()) {}
         /// Make movable
         hmac(hmac &&);
-
         ~hmac();
 
         hmac &operator<<(const const_memory_block &);

--- a/Cpp/include/fost/ed25519.hpp
+++ b/Cpp/include/fost/ed25519.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2018, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -39,9 +39,10 @@ namespace fostlib {
           public:
             /// Create a new keypair
             explicit keypair();
-
             /// Create a keypair from a secret
             explicit keypair(secret);
+            /// Create a keypair from a memory buffer
+            keypair(f5::buffer<const f5::byte>);
 
             /// Return the secret and private parts
             secret priv() const {
@@ -57,6 +58,9 @@ namespace fostlib {
 
             /// Return a signature for the presented data
             std::array<f5::byte, 64> sign(f5::buffer<const f5::byte> data) const;
+
+            /// Allow conversion of the keypair to a memory buffer
+            operator f5::buffer<const f5::byte>() const { return privkey; }
         };
 
 

--- a/Cpp/include/fost/ed25519.hpp
+++ b/Cpp/include/fost/ed25519.hpp
@@ -13,77 +13,70 @@
 #include <fost/array>
 
 
-namespace fostlib {
+namespace fostlib::ed25519 {
 
 
-    namespace ed25519 {
+    /// A public or private key or other secret
+    using secret = std::array<f5::byte, 32>;
 
 
-        /// A public or private key or other secret
-        using secret = std::array<f5::byte, 32>;
+    /// A keypair for ed25519
+    class keypair {
+        /// The way the library we use thinks about the keys is that
+        /// there is a public key (32 bytes) and a secret key (64 bytes).
+        /// The secret is of course 32 bytes, but it's got the public key
+        /// appended to it (!!). Lots of the library implementations
+        /// rely on thiis :(
+        ///
+        /// We'll just store the two parts in a single 64 byte array
+        /// and call it done. The `priv` and `pub` accessors return
+        /// the correct parts.
+        std::array<f5::byte, 64> privkey;
 
+      public:
+        /// Create a new keypair
+        explicit keypair();
+        /// Create a keypair from a secret
+        explicit keypair(secret);
+        /// Create a keypair from a memory buffer
+        keypair(f5::buffer<const f5::byte>);
 
-        /// A keypair for ed25519
-        class keypair {
-            /// The way the library we use thinks about the keys is that
-            /// there is a public key (32 bytes) and a secret key (64 bytes).
-            /// The secret is of course 32 bytes, but it's got the public key
-            /// appended to it (!!). Lots of the library implementations
-            /// rely on thiis :(
-            ///
-            /// We'll just store the two parts in a single 64 byte array
-            /// and call it done. The `priv` and `pub` accessors return
-            /// the correct parts.
-            std::array<f5::byte, 64> privkey;
-
-          public:
-            /// Create a new keypair
-            explicit keypair();
-            /// Create a keypair from a secret
-            explicit keypair(secret);
-            /// Create a keypair from a memory buffer
-            keypair(f5::buffer<const f5::byte>);
-
-            /// Return the secret and private parts
-            secret priv() const {
-                secret s;
-                std::copy(privkey.data(), privkey.data() + 32, s.begin());
-                return s;
-            }
-            secret pub() const {
-                secret s;
-                std::copy(privkey.data() + 32, privkey.data() + 64, s.begin());
-                return s;
-            }
-
-            /// Return a signature for the presented data
-            std::array<f5::byte, 64> sign(f5::buffer<const f5::byte> data) const;
-
-            /// Allow conversion of the keypair to a memory buffer
-            operator f5::buffer<const f5::byte>() const { return privkey; }
-        };
-
-
-        /// Verify a signed message has been signed with the provided public key
-        bool
-                verify(secret pub,
-                       f5::buffer<const f5::byte> msg,
-                       f5::buffer<const f5::byte> sig);
-
-        inline bool
-                verify(secret pub,
-                       const std::string &msg,
-                       f5::buffer<const f5::byte> sig) {
-            return verify(
-                    pub,
-                    f5::buffer<const f5::byte>{
-                            reinterpret_cast<unsigned char const *>(msg.data()),
-                            msg.size()},
-                    sig);
+        /// Return the secret and private parts
+        secret priv() const {
+            secret s;
+            std::copy(privkey.data(), privkey.data() + 32, s.begin());
+            return s;
+        }
+        secret pub() const {
+            secret s;
+            std::copy(privkey.data() + 32, privkey.data() + 64, s.begin());
+            return s;
         }
 
+        /// Return a signature for the presented data
+        std::array<f5::byte, 64> sign(f5::buffer<const f5::byte> data) const;
 
+        /// Allow conversion of the keypair to a memory buffer
+        operator f5::buffer<const f5::byte>() const { return privkey; }
+    };
+
+
+    /// Verify a signed message has been signed with the provided public key
+    bool
+            verify(f5::buffer<const f5::byte> pub,
+                   f5::buffer<const f5::byte> msg,
+                   f5::buffer<const f5::byte> sig);
+
+    inline bool
+            verify(f5::buffer<const f5::byte> pub,
+                   const std::string &msg,
+                   f5::buffer<const f5::byte> sig) {
+        return verify(
+                pub,
+                f5::buffer<const f5::byte>{
+                        reinterpret_cast<unsigned char const *>(msg.data()),
+                        msg.size()},
+                sig);
     }
-
 
 }

--- a/Cpp/include/fost/ed25519.hpp
+++ b/Cpp/include/fost/ed25519.hpp
@@ -64,6 +64,25 @@ namespace fostlib {
         };
 
 
+        /// Verify a signed message has been signed with the provided public key
+        bool
+                verify(secret pub,
+                       f5::buffer<const f5::byte> msg,
+                       f5::buffer<const f5::byte> sig);
+
+        inline bool
+                verify(secret pub,
+                       const std::string &msg,
+                       f5::buffer<const f5::byte> sig) {
+            return verify(
+                    pub,
+                    f5::buffer<const f5::byte>{
+                            reinterpret_cast<unsigned char const *>(msg.data()),
+                            msg.size()},
+                    sig);
+        }
+
+
     }
 
 

--- a/Cpp/include/fost/jwt.hpp
+++ b/Cpp/include/fost/jwt.hpp
@@ -78,30 +78,26 @@ namespace fostlib {
         struct token {
             /// Load the token with a secret returned by the lambda
             static nullable<token>
-                    load(const std::function<std::vector<f5::byte>(json, json)>
-                                 &lambda,
-                         f5::u8view jwt);
+                    load(f5::u8view jwt,
+                         const std::function<std::vector<f5::byte>(json, json)>
+                                 &lambda);
             /// Load the token and return it if verified
             static nullable<token> load(string secret, f5::u8view jwt) {
-                return load(
-                        [secret = std::move(secret)](json, json) {
-                            return std::vector<f5::byte>(
-                                    secret.data().begin(), secret.data().end());
-                        },
-                        jwt);
+                return load(jwt, [secret = std::move(secret)](json, json) {
+                    return std::vector<f5::byte>(
+                            secret.data().begin(), secret.data().end());
+                });
             }
             [
                     [deprecated("Pass a lambda that returns a memory block not "
                                 "a string")]] static nullable<token>
                     load(const std::function<string(json, json)> &lambda,
                          f5::u8view jwt) {
-                return load(
-                        [lambda](json j1, json j2) {
-                            const auto s = lambda(j1, j2);
-                            return std::vector<f5::byte>(
-                                    s.data().begin(), s.data().end());
-                        },
-                        jwt);
+                return load(jwt, [lambda](json j1, json j2) {
+                    const auto s = lambda(j1, j2);
+                    return std::vector<f5::byte>(
+                            s.data().begin(), s.data().end());
+                });
             }
             /// The token header and payload
             const json header, payload;

--- a/Cpp/include/fost/jwt.hpp
+++ b/Cpp/include/fost/jwt.hpp
@@ -20,7 +20,7 @@ namespace fostlib {
 
 
         /// The digest algorithms that are supported
-        enum digest { hs256 };
+        enum class alg { HS256, EdDSA };
 
         /// The encryption algorithms that are supported
         enum encryption {};
@@ -28,14 +28,18 @@ namespace fostlib {
 
         /// Create a JWT
         class mint {
+            alg algorithm;
             hmac digester;
             json header, m_payload;
 
           public:
+            /// Set up the parameters used for creating the JWT
+            mint(alg, json payload = json::object_t{});
+
             /// Set up for creating a signed JWT
-            mint(digester_fn d,
-                 const string &key,
-                 json payload = json::object_t{});
+            [[deprecated(
+                    "Set the algorithm to use, not the digest "
+                    "function")]] mint(digester_fn d, const string &key, json payload = json::object_t{});
             /// Make movable
             mint(mint &&);
 
@@ -51,7 +55,10 @@ namespace fostlib {
             mint &claim(f5::u8view url, const json &value);
 
             /// Return the token
-            std::string token();
+            [[deprecated(
+                    "Pass the key in here, not in the constructor")]] std::string
+                    token();
+            std::string token(f5::buffer<const f5::byte> key);
 
             /// Return the current payload
             const json &payload() const { return m_payload; }

--- a/Cpp/include/fost/jwt.hpp
+++ b/Cpp/include/fost/jwt.hpp
@@ -65,6 +65,15 @@ namespace fostlib {
         };
 
 
+        /// Low level API for signing the header and payload BASE64 encoded
+        /// parts of the JWT and returning the signed version
+        [[nodiscard]] std::string sign_base64_jwt(
+                f5::u8view header_b64,
+                f5::u8view payload_b64,
+                alg,
+                f5::buffer<const f5::byte> key);
+
+
         /// Check a JWT
         struct token {
             /// Load the token with a secret returned by the lambda

--- a/Cpp/include/fost/jwt.hpp
+++ b/Cpp/include/fost/jwt.hpp
@@ -78,13 +78,28 @@ namespace fostlib {
         struct token {
             /// Load the token with a secret returned by the lambda
             static nullable<token>
-                    load(const std::function<string(json, json)> &lambda,
+                    load(const std::function<std::vector<f5::byte>(json, json)>
+                                 &lambda,
                          f5::u8view jwt);
             /// Load the token and return it if verified
             static nullable<token> load(string secret, f5::u8view jwt) {
                 return load(
                         [secret = std::move(secret)](json, json) {
-                            return secret;
+                            return std::vector<f5::byte>(
+                                    secret.data().begin(), secret.data().end());
+                        },
+                        jwt);
+            }
+            [
+                    [deprecated("Pass a lambda that returns a memory block not "
+                                "a string")]] static nullable<token>
+                    load(const std::function<string(json, json)> &lambda,
+                         f5::u8view jwt) {
+                return load(
+                        [lambda](json j1, json j2) {
+                            const auto s = lambda(j1, j2);
+                            return std::vector<f5::byte>(
+                                    s.data().begin(), s.data().end());
                         },
                         jwt);
             }

--- a/Cpp/include/fost/string.hpp
+++ b/Cpp/include/fost/string.hpp
@@ -83,6 +83,12 @@ namespace fostlib {
         native_literal c_str() const { return m_string.c_str(); }
         /// Return the native string version of the string
         const native_string &std_str() const { return m_string; }
+        /// Return the memory for the underlying string
+        f5::buffer<const f5::byte> data() const {
+            return f5::buffer<const f5::byte>{
+                    reinterpret_cast<unsigned char const *>(m_string.data()),
+                    m_string.size()};
+        }
 
         /// Freely convert to a f5::u8view.`
         operator f5::u8view() const { return f5::u8view(m_string); }


### PR DESCRIPTION
This should support EdDSA JWTs now. There is only a single example in the RFC and very little support for these elsewhere, but they should be correct.

The JWT APIs have been changed around quite a lot and many of the old ones deprecated. The APIs are still not great though. In particular the lambda version of the checker now has to return a `std::vector` which is pretty icky for the cases where there is already a long lived memory buffer that is suitable.

The fact that the Ed25519 key pair also returns `std::array` instances can also cause problems as they don't upgrade in the lambda cleanly to a `std::vector`. Nor for that matter do any of the string types. It's not clear to me yet what a better API would look like.