### PR TITLE
Remove unused parameter names.

### DIFF
--- a/Cpp/fost-cli/arguments.cpp
+++ b/Cpp/fost-cli/arguments.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 1995-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 1995-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -52,7 +52,7 @@ void fostlib::arguments::load(const native_char *const envp[]) {
 }
 
 
-string fostlib::arguments::environment(const string &env_name) {
+string fostlib::arguments::environment(const string &) {
 #ifdef FOST_OS_WINDOWS
     DWORD length = GetEnvironmentVariable(L"windir", NULL, 0);
     if (length) {

--- a/Cpp/fost-cli/main_exec.cpp
+++ b/Cpp/fost-cli/main_exec.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2008-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2008-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -47,7 +47,7 @@ void fostlib::standard_arguments(
 
 
 namespace {
-    int exception_wrapper(fostlib::ostream &out, std::function<int(void)> f) {
+    int exception_wrapper(fostlib::ostream &, std::function<int(void)> f) {
         try {
             fostlib::exceptions::structured_handler handler;
 #ifdef WIN32

--- a/Cpp/fost-core/json-coerce.cpp
+++ b/Cpp/fost-core/json-coerce.cpp
@@ -108,15 +108,15 @@ namespace {
             throw fostlib::exceptions::null(
                     "Cannot convert null to f5::u8view");
         }
-        f5::u8view operator()(bool b) const {
+        f5::u8view operator()(bool) const {
             throw fostlib::exceptions::cast_fault(
                     "Cannot convert bool to f5::u8view");
         }
-        f5::u8view operator()(int64_t i) const {
+        f5::u8view operator()(int64_t) const {
             throw fostlib::exceptions::cast_fault(
                     "Cannot convert int64_t to f5::u8view");
         }
-        f5::u8view operator()(double d) const {
+        f5::u8view operator()(double) const {
             throw fostlib::exceptions::cast_fault(
                     "Cannot convert double to f5::u8view");
         }
@@ -124,13 +124,13 @@ namespace {
         f5::u8view operator()(const json::string_p &s) const {
             return f5::u8view(*s);
         }
-        f5::u8view operator()(const json::array_p &a) const {
+        f5::u8view operator()(json::array_p const &a) const {
             fostlib::exceptions::cast_fault error(
                     "Cannot convert a JSON array to a string");
             fostlib::insert(error.data(), "array", *a);
             throw error;
         }
-        f5::u8view operator()(const json::object_p &o) const {
+        f5::u8view operator()(json::object_p const &o) const {
             fostlib::exceptions::cast_fault error(
                     "Cannot convert a JSON object to a string");
             fostlib::insert(error.data(), "object", *o);
@@ -144,19 +144,19 @@ f5::u8view fostlib::coercer<f5::u8view, json>::coerce(const json &j) {
 namespace {
     struct as_nullable_u8view {
         nullable<f5::u8view> operator()(std::monostate) const { return null; }
-        nullable<f5::u8view> operator()(bool b) const { return null; }
-        nullable<f5::u8view> operator()(int64_t i) const { return null; }
-        nullable<f5::u8view> operator()(double d) const { return null; }
+        nullable<f5::u8view> operator()(bool) const { return null; }
+        nullable<f5::u8view> operator()(int64_t) const { return null; }
+        nullable<f5::u8view> operator()(double) const { return null; }
         nullable<f5::u8view> operator()(f5::lstring s) const {
             return f5::u8view(s);
         }
         nullable<f5::u8view> operator()(const json::string_p &s) const {
             return f5::u8view(*s);
         }
-        nullable<f5::u8view> operator()(const json::array_p &a) const {
+        nullable<f5::u8view> operator()(const json::array_p &) const {
             return null;
         }
-        nullable<f5::u8view> operator()(const json::object_p &o) const {
+        nullable<f5::u8view> operator()(const json::object_p &) const {
             return null;
         }
     };

--- a/Cpp/fost-core/json-order.cpp
+++ b/Cpp/fost-core/json-order.cpp
@@ -19,7 +19,7 @@ namespace {
         bool operator()(std::monostate) const { return false; }
         bool operator()(bool right) const { return left < right; }
         template<typename O>
-        bool operator()(const O &o) const {
+        bool operator()(const O &) const {
             return true;
         }
     };
@@ -27,11 +27,11 @@ namespace {
         const int64_t left;
         compare_int(int64_t l) : left(l) {}
         bool operator()(std::monostate) const { return false; }
-        bool operator()(bool right) const { return false; }
+        bool operator()(bool) const { return false; }
         bool operator()(int64_t right) const { return left < right; }
         bool operator()(double right) const { return double(left) < right; }
         template<typename O>
-        bool operator()(const O &o) const {
+        bool operator()(const O &) const {
             return true;
         }
     };
@@ -39,11 +39,11 @@ namespace {
         const double left;
         compare_double(double l) : left(l) {}
         bool operator()(std::monostate) const { return false; }
-        bool operator()(bool right) const { return false; }
+        bool operator()(bool) const { return false; }
         bool operator()(int64_t right) const { return left < double(right); }
         bool operator()(double right) const { return left < right; }
         template<typename O>
-        bool operator()(const O &o) const {
+        bool operator()(const O &) const {
             return true;
         }
     };
@@ -51,7 +51,7 @@ namespace {
         f5::u8view left;
         compare_u8view(f5::u8view l) : left(l) {}
         template<typename O>
-        bool operator()(const O &o) const {
+        bool operator()(const O &) const {
             return false;
         }
         bool operator()(f5::lstring right) const { return left < right; }
@@ -76,14 +76,14 @@ namespace {
                         return std::less<fostlib::json>()(left, right);
                     });
         }
-        bool operator()(const fostlib::json::object_p &o) const { return true; }
+        bool operator()(const fostlib::json::object_p &) const { return true; }
     };
 
     struct compare_object {
         const fostlib::json::object_t &left;
         compare_object(const fostlib::json::object_t &l) : left(l) {}
         template<typename O>
-        bool operator()(const O &right) const {
+        bool operator()(const O &) const {
             return false;
         }
         bool operator()(const fostlib::json::object_p &right) const {

--- a/Cpp/fost-core/json.cpp
+++ b/Cpp/fost-core/json.cpp
@@ -244,7 +244,7 @@ namespace {
             }
         }
         template<typename T>
-        const json &operator()(const T &t) const {
+        const json &operator()(const T &) const {
             throw exceptions::out_of_range<json::array_t::size_type, uint64_t>(
                     0, 0, p);
         }
@@ -368,7 +368,7 @@ namespace {
                     L"fostlib::json::const_iterator::key() const -- for a null "
                     L"iterator");
         }
-        json operator()(const json::array_t::const_iterator &i) const {
+        json operator()(json::array_t::const_iterator const &) const {
             throw exceptions::not_implemented(
                     L"fostlib::json::const_iterator::key() const -- for an "
                     L"array iterator");

--- a/Cpp/fost-core/string-ascii.cpp
+++ b/Cpp/fost-core/string-ascii.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2009-2015, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2009-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -54,13 +54,13 @@ namespace {
 
 
 void fostlib::ascii_string_tag::do_encode(
-        fostlib::nliteral from, std::string &into) {
+        fostlib::nliteral, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::ascii_string_tag::do_encode( fostlib::nliteral from, "
             L"std::string &into )");
 }
 void fostlib::ascii_string_tag::do_encode(
-        const std::string &from, std::string &into) {
+        const std::string &, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::ascii_string_tag::do_encode( const std::string &from, "
             L"std::string &into )");
@@ -108,13 +108,13 @@ fostlib::json fostlib::coercer<fostlib::json, fostlib::ascii_string>::coerce(
 
 
 void fostlib::ascii_printable_string_tag::do_encode(
-        fostlib::nliteral from, std::string &into) {
+        fostlib::nliteral, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::ascii_printable_string_tag::do_encode( "
             L"fostlib::nliteral from, std::string &into )");
 }
 void fostlib::ascii_printable_string_tag::do_encode(
-        const std::string &from, std::string &into) {
+        const std::string &, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::ascii_printable_string_tag::do_encode( const "
             L"std::string &from, std::string &into )");

--- a/Cpp/fost-core/string-tagged.cpp
+++ b/Cpp/fost-core/string-tagged.cpp
@@ -24,13 +24,13 @@
 
 
 void fostlib::utf8_string_tag::do_encode(
-        fostlib::nliteral from, std::string &into) {
+        fostlib::nliteral, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::utf8_string_tag::do_encode( fostlib::nliteral from, "
             L"std::string &into )");
 }
 void fostlib::utf8_string_tag::do_encode(
-        const std::string &from, std::string &into) {
+        const std::string &, std::string &) {
     throw fostlib::exceptions::not_implemented(
             L"fostlib::utf8_string_tag::do_encode( const std::string &from, "
             L"std::string &into )");
@@ -135,12 +135,12 @@ namespace {
 }
 
 void fostlib::base64_string_tag::do_encode(
-        fostlib::nliteral from, ascii_string &into) {
+        fostlib::nliteral, ascii_string &) {
     throw fostlib::exceptions::not_implemented(__func__);
 }
 
 void fostlib::base64_string_tag::do_encode(
-        const ascii_string &from, ascii_string &into) {
+        const ascii_string &, ascii_string &) {
     throw fostlib::exceptions::not_implemented(__func__);
 }
 
@@ -247,14 +247,14 @@ namespace {
 }
 
 void fostlib::hex_string_tag::do_encode(
-        fostlib::nliteral from, ascii_string &into) {
+        fostlib::nliteral, ascii_string &) {
     throw fostlib::exceptions::not_implemented(
             "fostlib::hex_string_tag::do_encode( fostlib::nliteral from, "
             "ascii_string &into )");
 }
 
 void fostlib::hex_string_tag::do_encode(
-        const ascii_string &from, ascii_string &into) {
+        const ascii_string &, ascii_string &) {
     throw fostlib::exceptions::not_implemented(
             "fostlib::hex_string_tag::do_encode( const ascii_string &from, "
             "ascii_string &into )");

--- a/Cpp/fost-core/timestamp-rfc1123.cpp
+++ b/Cpp/fost-core/timestamp-rfc1123.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2000-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2000-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -16,13 +16,13 @@
 using namespace fostlib;
 
 
-/*
-    fostlib::rfc1123_timestamp
+/**
+    ## `fostlib::rfc1123_timestamp`
 */
 
 
 void fostlib::rfc1123_timestamp_tag::do_encode(
-        fostlib::nliteral from, ascii_string &into) {
+        fostlib::nliteral, ascii_string &) {
     throw exceptions::not_implemented(
             "fostlib::rfc1123_timestamp_tag::do_encode( fostlib::nliteral "
             "from, ascii_string &into )");
@@ -30,7 +30,7 @@ void fostlib::rfc1123_timestamp_tag::do_encode(
 
 
 void fostlib::rfc1123_timestamp_tag::do_encode(
-        const ascii_string &from, ascii_string &into) {
+        const ascii_string &, ascii_string &) {
     throw exceptions::not_implemented(
             "fostlib::rfc1123_timestamp_tag::do_encode( const ascii_string "
             "&from, ascii_string &into )");

--- a/Cpp/fost-crypto/signature.cpp
+++ b/Cpp/fost-crypto/signature.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 1999-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 1999-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -135,7 +135,7 @@ fostlib::hmac &fostlib::hmac::operator<<(const fostlib::string &data) {
 }
 
 fostlib::hmac &fostlib::hmac::
-        operator<<(const boost::filesystem::path &filename) {
+        operator<<(const boost::filesystem::path &) {
     throw fostlib::exceptions::not_implemented(
             "fostlib::hmac::operator << ( const boost::filesystem::path "
             "&filename )");

--- a/Examples/hash/hash.cpp
+++ b/Examples/hash/hash.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2013-2018, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2013-2018, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -25,7 +25,7 @@ using namespace fostlib;
 
 
 namespace {
-    string hash(meter &tracker, const boost::filesystem::path &file) {
+    string hash(meter &, const boost::filesystem::path &file) {
         digester hasher(md5);
         hasher << file;
         return coerce<string>(coerce<hex_string>(hasher.digest()));


### PR DESCRIPTION
These parameters aren't used so don't need to be named. Silences higher level warnings on both gcc and clang.