### PR TITLE
Split the CMake configuraion into smaller parts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,49 +5,10 @@ set(CMAKE_INSTALL_PREFIX ../dist
 set(BUILD_SHARED_LIBS ON
     CACHE BOOL "Build shared libraries")
 
-set(SMOKE_TEST_RUNNER_CPP
-    ${CMAKE_CURRENT_SOURCE_DIR}/Cpp/fost-test/boost-build-unit-test.cpp
-    CACHE INTERNAL "Unit test runner main.cpp")
-
-function(smoke_test name)
-    add_executable(${name}-check EXCLUDE_FROM_ALL
-        ${SMOKE_TEST_RUNNER_CPP})
-    if(APPLE)
-        target_link_libraries(${name}-check
-            -Wl,-force_load ${name}
-            fost-test fost-cli)
-    else()
-        target_link_libraries(${name}-check
-            -Wl,--whole-archive ${name} -Wl,--no-whole-archive
-            fost-test fost-cli)
-    endif()
-    add_custom_command(TARGET ${name}-check
-        POST_BUILD COMMAND ${name}-check -b false -v false)
-    add_dependencies(check ${name}-check)
-    add_test(NAME ${name}-ctest COMMAND ${name}-check)
-endfunction()
-
+include(./smoke_test.cmake)
+include(./stress_test.cmake)
 if(TARGET stress)
     set_property(TARGET stress PROPERTY EXCLUDE_FROM_ALL TRUE)
 endif()
-function(stress_test name)
-    add_executable(${name}-check EXCLUDE_FROM_ALL
-        ${SMOKE_TEST_RUNNER_CPP})
-    if(APPLE)
-        target_link_libraries(${name}-check
-            -Wl,-force_load ${name}
-            fost-test fost-cli)
-    else()
-        target_link_libraries(${name}-check
-            -Wl,--whole-archive ${name} -Wl,--no-whole-archive
-            fost-test fost-cli)
-    endif()
-    add_custom_command(TARGET ${name}-check
-        POST_BUILD COMMAND ${name}-check -b false -v false)
-    if(TARGET stress)
-        add_dependencies(stress ${name}-check)
-    endif()
-    add_test(NAME ${name}-ctest COMMAND ${name}-check)
-endfunction()
 
 add_subdirectory(Cpp)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 2018-12-18  Kirit Saelensminde  <kirit@felspar.com>
+ Split the CMake configuraion into smaller parts.
+
+2018-12-18  Kirit Saelensminde  <kirit@felspar.com>
  Changes to string handling to support wider adoption of `f5::u8string`
 
 2018-12-01  Kirit Saelensminde  <kirit@felspar.com>

--- a/smoke_test.cmake
+++ b/smoke_test.cmake
@@ -1,0 +1,21 @@
+set(SMOKE_TEST_RUNNER_CPP
+    ${CMAKE_CURRENT_LIST_DIR}/Cpp/fost-test/boost-build-unit-test.cpp
+    CACHE INTERNAL "Unit test runner main.cpp for check tests")
+
+function(smoke_test name)
+    add_executable(${name}-check EXCLUDE_FROM_ALL
+        ${SMOKE_TEST_RUNNER_CPP})
+    if(APPLE)
+        target_link_libraries(${name}-check
+            -Wl,-force_load ${name}
+            fost-test fost-cli)
+    else()
+        target_link_libraries(${name}-check
+            -Wl,--whole-archive ${name} -Wl,--no-whole-archive
+            fost-test fost-cli)
+    endif()
+    add_custom_command(TARGET ${name}-check
+        POST_BUILD COMMAND ${name}-check -b false -v false)
+    add_dependencies(check ${name}-check)
+    add_test(NAME ${name}-ctest COMMAND ${name}-check)
+endfunction()

--- a/stress_test.cmake
+++ b/stress_test.cmake
@@ -1,0 +1,23 @@
+set(STRESS_TEST_RUNNER_CPP
+    ${CMAKE_CURRENT_LIST_DIR}/Cpp/fost-test/boost-build-unit-test.cpp
+    CACHE INTERNAL "Unit test runner main.cpp for stress tests")
+
+function(stress_test name)
+    add_executable(${name}-check EXCLUDE_FROM_ALL
+        ${STRESS_TEST_RUNNER_CPP})
+    if(APPLE)
+        target_link_libraries(${name}-check
+            -Wl,-force_load ${name}
+            fost-test fost-cli)
+    else()
+        target_link_libraries(${name}-check
+            -Wl,--whole-archive ${name} -Wl,--no-whole-archive
+            fost-test fost-cli)
+    endif()
+    add_custom_command(TARGET ${name}-check
+        POST_BUILD COMMAND ${name}-check -b false -v false)
+    if(TARGET stress)
+        add_dependencies(stress ${name}-check)
+    endif()
+    add_test(NAME ${name}-ctest COMMAND ${name}-check)
+endfunction()


### PR DESCRIPTION
This change allows us to pick parts of fost-base without needing to bring it all and still be able to get smoke and stress tests.

This is really useful if we have something that doesn't need the crypto library.