### PR TITLE
Implement string conversion (ISO Zulu time) for `std::chrono::system_clock`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-02-28  Kirit Saelensminde  <kirit@felspar.com>
+ Implement string conversion (ISO Zulu time) for `std::chrono::system_clock`
+
 2019-02-24  Kirit Saelensminde  <kirit@felspar.com>
  Add new nonce functions that return base64url formatted random data in ordered and un-ordered variants.
 

--- a/Cpp/fost-core/timestamp.cpp
+++ b/Cpp/fost-core/timestamp.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2000-2014, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2000-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -14,6 +14,24 @@
 
 
 using namespace fostlib;
+
+
+string fostlib::coercer<string, std::chrono::system_clock::time_point>::coerce(
+        std::chrono::system_clock::time_point const t) {
+    auto const seconds = std::chrono::floor<std::chrono::seconds>(t);
+    auto const sec_part = t - seconds;
+    int64_t const ns =
+            std::chrono::duration<uint64_t, std::nano>(sec_part).count();
+    auto const tt = std::chrono::system_clock::to_time_t(t);
+
+    std::stringstream ss;
+    ss << std::put_time(std::gmtime(&tt), "%FT%T.");
+    ss.width(9);
+    ss.fill('0');
+    ss << ns << "Z";
+
+    return string{ss.str()};
+}
 
 
 string fostlib::coercer<string, timestamp>::coerce(timestamp t) {

--- a/Cpp/include/fost/timer.hpp
+++ b/Cpp/include/fost/timer.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2011-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2011-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -23,30 +23,43 @@ namespace fostlib {
 
 
     /// A simple timer for measuring the duration of something
+    /**
+        The clock resolution for the start time may not be as high as one
+        would want.
+     */
     class timer final {
-        std::chrono::time_point<std::chrono::steady_clock> started;
+        std::chrono::steady_clock::time_point steady;
+        std::chrono::system_clock::time_point start;
 
       public:
         /// Construct and start the timer
-        timer() : started(std::chrono::steady_clock::now()) {}
+        timer()
+        : steady{std::chrono::steady_clock::now()},
+          start{std::chrono::system_clock::now()} {}
+
+        /// Return when the timer started or was last reset
+        auto started() const { return start; }
 
         /// The number of seconds that have elapsed
         template<typename Duration>
         Duration elapsed() const {
             auto now = std::chrono::steady_clock::now();
-            return std::chrono::duration_cast<Duration>(now - started);
+            return std::chrono::duration_cast<Duration>(now - steady);
         }
 
         /// Return the number of seconds
         double seconds() const {
-            auto now = std::chrono::steady_clock::now();
-            auto taken = now - started;
+            auto const now = std::chrono::steady_clock::now();
+            auto const taken = now - steady;
             return double(taken.count()) * decltype(taken)::period::num
                     / decltype(taken)::period::den;
         }
 
         /// Reset the timer so we can start to record again
-        void reset() { started = std::chrono::steady_clock::now(); }
+        void reset() {
+            steady = std::chrono::steady_clock::now();
+            start = std::chrono::system_clock::now();
+        }
     };
 
 

--- a/Cpp/include/fost/timer.hpp
+++ b/Cpp/include/fost/timer.hpp
@@ -24,8 +24,14 @@ namespace fostlib {
 
     /// A simple timer for measuring the duration of something
     /**
-        The clock resolution for the start time may not be as high as one
-        would want.
+        Clock handling for this case is in tension. We want to be able to
+        have the start time be the wall clock, but we need to measure the
+        duration using a steady clock, hence the use of two clocks.
+
+        If we use only `steady_clock` then the start time may bear little
+        relation to the current time as expected by a user. If we only use
+        the `system_clock` then adjustments of the clock (through say ntp)
+        will cause the duration to be inaccurate.
      */
     class timer final {
         std::chrono::steady_clock::time_point steady;

--- a/Cpp/include/fost/timestamp.hpp
+++ b/Cpp/include/fost/timestamp.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2000-2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2000-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -17,6 +17,7 @@
 #include <fost/utility-nullable.hpp>
 #include <fost/file.hpp>
 
+#include <chrono>
 #include <utility>
 
 
@@ -180,6 +181,19 @@ namespace fostlib {
             string s(fostlib::coerce<string>(ts));
             return fostlib::coerce<boost::filesystem::path>(
                     replace_all(s, ":"));
+        }
+    };
+
+
+    /// Conversion of `std::chrono::system_clock::time_point` to useful formats
+    template<>
+    struct coercer<string, std::chrono::system_clock::time_point> {
+        string coerce(std::chrono::system_clock::time_point);
+    };
+    template<>
+    struct coercer<json, std::chrono::system_clock::time_point> {
+        json coerce(std::chrono::system_clock::time_point t) {
+            return json{fostlib::coerce<string>(t)};
         }
     };
 


### PR DESCRIPTION
The main API we need on our old `timestamp` class is to just be able to convert to Zulu time strings. This adds that for the newer `chrono` clock and exposes the start time on timers.
