### PR TITLE
Fix rare problem with dlclose

### DIFF
--- a/Cpp/fost-core/dynlib.cpp
+++ b/Cpp/fost-core/dynlib.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2008-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2008-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -58,6 +58,10 @@ struct fostlib::dynlib::impl {
 fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
     fostlib::json attempts;
     const auto tryload = [&attempts](string dl) {
+        /**
+         * Using `RTLD_NODELETE` may seem like a good idea here, but it
+         * turns out that things don't work at all well with that.
+         */
         void *h = dlopen(dl.c_str(), RTLD_NOW);
         if (not h)
             fostlib::insert(
@@ -90,10 +94,10 @@ fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
 fostlib::dynlib::~dynlib() {
     /**
         We don't want to actually unload the .so yet as there may well still be
-       objects that it manages.
+        objects that it manages.
 
-        The choice of adding the deletion to `atexit` here is somewhat
-       arbitrary. It could have just as easily gone in the constructor
+        By putting the deletion in the `atexit` handler we should ensure that
+        the libraries are unloaded in the right order (that of the destructors).
     */
     if (m_lib) fostlib::atexit([libp = m_lib]() { delete libp; });
 }

--- a/Cpp/fost-core/dynlib.cpp
+++ b/Cpp/fost-core/dynlib.cpp
@@ -58,7 +58,7 @@ struct fostlib::dynlib::impl {
 fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
     fostlib::json attempts;
     const auto tryload = [&attempts](string dl) {
-        void *h = dlopen(dl.c_str(), RTLD_NOW);
+        void *h = dlopen(dl.c_str(), RTLD_NOW | RTLD_NODELETE);
         if (not h)
             fostlib::insert(
                     attempts, std::move(dl), fostlib::string(dlerror()));

--- a/Cpp/fost-core/dynlib.cpp
+++ b/Cpp/fost-core/dynlib.cpp
@@ -58,7 +58,7 @@ struct fostlib::dynlib::impl {
 fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
     fostlib::json attempts;
     const auto tryload = [&attempts](string dl) {
-        void *h = dlopen(dl.c_str(), RTLD_NOW | RTLD_NODELETE);
+        void *h = dlopen(dl.c_str(), RTLD_NOW);
         if (not h)
             fostlib::insert(
                     attempts, std::move(dl), fostlib::string(dlerror()));

--- a/Cpp/fost-core/dynlib.cpp
+++ b/Cpp/fost-core/dynlib.cpp
@@ -99,7 +99,7 @@ fostlib::dynlib::~dynlib() {
         By putting the deletion in the `atexit` handler we should ensure that
         the libraries are unloaded in the right order (that of the destructors).
     */
-    if (m_lib) fostlib::atexit([libp = m_lib]() { delete libp; });
+//     if (m_lib) fostlib::atexit([libp = m_lib]() { delete libp; });
 }
 
 

--- a/Cpp/fost-core/dynlib.cpp
+++ b/Cpp/fost-core/dynlib.cpp
@@ -47,20 +47,34 @@ using namespace fostlib;
 
 struct fostlib::dynlib::impl {
     impl(void *h) : handle(h) {}
-    ~impl() {
-        if (handle) dlclose(handle);
-    }
+    /**
+        We don't want to actually unload the .so yet as there may well still be
+        objects that it manages.
+
+        By putting the deletion in the `atexit` handler we could ensure that
+        the libraries are unloaded in the right order (that of the destructors).
+        But it turns out that `dlclose` may sometimes still assert and cause
+        the program to shutdown uncleanly. As a consequence we just leak
+        the handle :-(
+
+        ```cpp
+        ~impl() {
+            if (handle) dlclose(handle);
+        }
+        ```
+     */
     string name;
     void *handle;
 };
 
 
-fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
+fostlib::dynlib::dynlib(const string &lib) {
     fostlib::json attempts;
     const auto tryload = [&attempts](string dl) {
         /**
-         * Using `RTLD_NODELETE` may seem like a good idea here, but it
-         * turns out that things don't work at all well with that.
+            On Linux (but not POSIX), using `RTLD_NODELETE` may seem like
+            a good idea here, but it turns out that things don't work at
+            all well with that. `dlclose` may still assert on exit :-(
          */
         void *h = dlopen(dl.c_str(), RTLD_NOW);
         if (not h)
@@ -86,21 +100,12 @@ fostlib::dynlib::dynlib(const string &lib) : m_lib(nullptr) {
         fostlib::insert(err.data(), "attempted", attempts);
         throw err;
     }
-    m_lib = new fostlib::dynlib::impl(handle);
+    m_lib = std::make_unique<fostlib::dynlib::impl>(handle);
     m_lib->name = lib;
 }
 
 
-fostlib::dynlib::~dynlib() {
-    /**
-        We don't want to actually unload the .so yet as there may well still be
-        objects that it manages.
-
-        By putting the deletion in the `atexit` handler we should ensure that
-        the libraries are unloaded in the right order (that of the destructors).
-    */
-//     if (m_lib) fostlib::atexit([libp = m_lib]() { delete libp; });
-}
+fostlib::dynlib::~dynlib() = default;
 
 
 #endif

--- a/Cpp/include/fost/dynlib.hpp
+++ b/Cpp/include/fost/dynlib.hpp
@@ -1,21 +1,27 @@
-/*
-    Copyright 2008, Felspar Co Ltd. http://fost.3.felspar.com/
+/**
+    Copyright 2008-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
+
+
+#pragma once
 
 
 #ifndef FOST_DYNLIB_HPP
 #define FOST_DYNLIB_HPP
 
 
+#include <memory>
+
+
 namespace fostlib {
 
 
-    class FOST_CORE_DECLSPEC dynlib : boost::noncopyable {
+    class FOST_CORE_DECLSPEC dynlib final {
         struct impl;
-        impl *m_lib;
+        std::unique_ptr<impl> m_lib;
 
       public:
         dynlib(const string &path);


### PR DESCRIPTION
Sigh.... Just leak the resource because working out what dlclose really wants is nearly impossible, and we only ever do it on shutdown anyway, so just let the operating system deal with it.