### PR TITLE
Support switch to `std::filesystem`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-04-02  Kirit Saelensminde  <kirit@felspar.com>
+ Use of define `FSL_FORCE_STD_FILESYSTEM` switches from `boost::filesystem` to `std::filesystem` with names in `fostlib::fs`.
+
 2019-02-28  Kirit Saelensminde  <kirit@felspar.com>
  Implement string conversion (ISO Zulu time) for `std::chrono::system_clock`
 

--- a/Cpp/fost-core-test/file-io.cpp
+++ b/Cpp/fost-core-test/file-io.cpp
@@ -24,7 +24,7 @@ FSL_MAIN(
     auto filename(coerce<fostlib::fs::path>(args[1].value()));
     // Check that we can do some basic reads
     { // Build a basic text stream that we want to check against
-        fostlib::fs::ofstream outfile(filename);
+        fostlib::ofstream outfile(filename);
         outfile.write("abcdef\n", 7);
         unsigned char tm[] = {0xe2, 0x84, 0xa2, 0x00};
         outfile.write(reinterpret_cast<char *>(tm), 3);

--- a/Cpp/fost-core-test/file-io.cpp
+++ b/Cpp/fost-core-test/file-io.cpp
@@ -21,10 +21,10 @@ FSL_MAIN(
         L"Test file I/O and its Unicode handling\n"
         L"Copyright (C) 2009-2015, Felspar Co. Ltd.")
 (fostlib::ostream &out, fostlib::arguments &args) {
-    auto filename(coerce<boost::filesystem::path>(args[1].value()));
+    auto filename(coerce<fostlib::fs::path>(args[1].value()));
     // Check that we can do some basic reads
     { // Build a basic text stream that we want to check against
-        boost::filesystem::ofstream outfile(filename);
+        fostlib::fs::ofstream outfile(filename);
         outfile.write("abcdef\n", 7);
         unsigned char tm[] = {0xe2, 0x84, 0xa2, 0x00};
         outfile.write(reinterpret_cast<char *>(tm), 3);
@@ -40,6 +40,6 @@ FSL_MAIN(
         out << std::endl;
         return 1;
     }
-    boost::filesystem::remove(filename);
+    fostlib::fs::remove(filename);
     return 0;
 }

--- a/Cpp/fost-core-test/file-io.cpp
+++ b/Cpp/fost-core-test/file-io.cpp
@@ -1,16 +1,15 @@
-/*
-    Copyright 2009-2015, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2009-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
 #include <fost/cli>
+#include <fost/filesystem.hpp>
 #include <fost/main>
 #include <fost/unicode>
-
-#include <boost/filesystem/fstream.hpp>
 
 
 using namespace fostlib;

--- a/Cpp/fost-core/CMakeLists.txt
+++ b/Cpp/fost-core/CMakeLists.txt
@@ -53,13 +53,13 @@ if(TARGET check)
     add_library(fost-core-smoke STATIC EXCLUDE_FROM_ALL
             base16.tests.cpp
             base32.tests.cpp
-            boost-filesystem-path-tests.cpp
             char-encoding-tests.cpp
             coercion-int-tests.cpp
             coercion-tests.cpp
             date-tests.cpp
             exception-tests.cpp
             file-tests.cpp
+            filesystem-path.tests.cpp
             hex-tests.cpp
             jcursor-tests.cpp
             json-array-basic-tests.cpp

--- a/Cpp/fost-core/exception.cpp
+++ b/Cpp/fost-core/exception.cpp
@@ -145,8 +145,8 @@ fostlib::exceptions::file_error::file_error(
 }
 fostlib::exceptions::file_error::file_error(
         const string &message,
-        const boost::filesystem::path &file,
-        boost::system::error_code error) noexcept
+        const fostlib::fs::path &file,
+        fostlib::error_code error) noexcept
 : exception(message) {
     try {
         insert(data(), "filename", file.string().c_str());

--- a/Cpp/fost-core/exception.cpp
+++ b/Cpp/fost-core/exception.cpp
@@ -236,7 +236,7 @@ fostlib::exceptions::not_implemented::not_implemented(
     insert(data(), "detail", extra);
 }
 fostlib::exceptions::not_implemented::not_implemented(
-        const string &func, boost::system::error_code error) noexcept
+        const string &func, fostlib::error_code error) noexcept
 : exception() {
     try {
         insert(data(), "function", func);
@@ -245,7 +245,7 @@ fostlib::exceptions::not_implemented::not_implemented(
 }
 fostlib::exceptions::not_implemented::not_implemented(
         const string &func,
-        boost::system::error_code error,
+        fostlib::error_code error,
         const string &mess) noexcept
 : exception(mess) {
     try {
@@ -415,7 +415,7 @@ fostlib::exceptions::unexpected_eof::unexpected_eof(
     } catch (...) { fostlib::absorb_exception(); }
 }
 fostlib::exceptions::unexpected_eof::unexpected_eof(
-        const string &msg, boost::system::error_code error) noexcept
+        const string &msg, fostlib::error_code error) noexcept
 : exception(msg) {
     try {
         insert(data(), "error", error);

--- a/Cpp/fost-core/file-tests.cpp
+++ b/Cpp/fost-core/file-tests.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2013-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2013-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -30,16 +30,16 @@ FSL_TEST_FUNCTION(join_paths) {
 
 
 FSL_TEST_FUNCTION(unique_filename) {
-    boost::filesystem::path path;
+    fostlib::fs::path path;
     FSL_CHECK_NOTHROW(path = fostlib::unique_filename());
-    FSL_CHECK(!boost::filesystem::exists(path));
+    FSL_CHECK(!fostlib::fs::exists(path));
 }
 
 
 FSL_TEST_FUNCTION(save_file) {
-    const boost::filesystem::path filename = "/nowhere/not-allowed.txt";
+    const fostlib::fs::path filename = "/nowhere/not-allowed.txt";
     FSL_CHECK_EXCEPTION(
             fostlib::utf::save_file(filename, "some text"),
             fostlib::exceptions::file_error &);
-    FSL_CHECK(not boost::filesystem::exists(filename));
+    FSL_CHECK(not fostlib::fs::exists(filename));
 }

--- a/Cpp/fost-core/file.cpp
+++ b/Cpp/fost-core/file.cpp
@@ -61,7 +61,7 @@ namespace {
 
 
 void fostlib::utf::save_file(
-        const boost::filesystem::path &filename, const string &content) {
+        const fostlib::fs::path &filename, const string &content) {
     std::ofstream file{filename.string()};
     if (not file.is_open())
         throw exceptions::file_error(
@@ -79,8 +79,8 @@ void fostlib::utf::save_file(
 }
 
 
-string fostlib::utf::load_file(const boost::filesystem::path &filename) {
-    boost::filesystem::ifstream file(filename);
+string fostlib::utf::load_file(const fostlib::fs::path &filename) {
+    fostlib::fs::ifstream file(filename);
     string text = loadfile(file);
     if ((!file.eof() && file.bad()) || text.empty())
         throw exceptions::unexpected_eof(
@@ -91,9 +91,8 @@ string fostlib::utf::load_file(const boost::filesystem::path &filename) {
 
 
 string fostlib::utf::load_file(
-        const boost::filesystem::path &filename,
-        const string &default_content) {
-    boost::filesystem::ifstream file(filename);
+        const fostlib::fs::path &filename, const string &default_content) {
+    fostlib::fs::ifstream file(filename);
     string text = loadfile(file);
     if ((!file.eof() && file.bad()) || text.empty())
         return default_content;
@@ -102,15 +101,14 @@ string fostlib::utf::load_file(
 }
 
 
-boost::filesystem::path fostlib::unique_filename() {
-    return boost::filesystem::temp_directory_path()
-            / coerce<boost::filesystem::path>(guid());
+fostlib::fs::path fostlib::unique_filename() {
+    return fostlib::fs::temp_directory_path()
+            / coerce<fostlib::fs::path>(guid());
 }
 
 
-boost::filesystem::path fostlib::join_paths(
-        const boost::filesystem::path &root,
-        const boost::filesystem::path &path) {
+fostlib::fs::path fostlib::join_paths(
+        const fostlib::fs::path &root, const fostlib::fs::path &path) {
     if (path.empty()) {
         return root;
     } else if (path.is_complete() || coerce<string>(path)[0] == '/') {

--- a/Cpp/fost-core/file.cpp
+++ b/Cpp/fost-core/file.cpp
@@ -15,6 +15,8 @@
 #include <fost/exception/unexpected_eof.hpp>
 #include <fost/exception/unicode_encoding.hpp>
 
+#include <fstream>
+
 
 using namespace fostlib;
 
@@ -80,7 +82,7 @@ void fostlib::utf::save_file(
 
 
 string fostlib::utf::load_file(const fostlib::fs::path &filename) {
-    fostlib::fs::ifstream file(filename);
+    fostlib::ifstream file(filename);
     string text = loadfile(file);
     if ((!file.eof() && file.bad()) || text.empty())
         throw exceptions::unexpected_eof(
@@ -92,7 +94,7 @@ string fostlib::utf::load_file(const fostlib::fs::path &filename) {
 
 string fostlib::utf::load_file(
         const fostlib::fs::path &filename, const string &default_content) {
-    fostlib::fs::ifstream file(filename);
+    fostlib::ifstream file(filename);
     string text = loadfile(file);
     if ((!file.eof() && file.bad()) || text.empty())
         return default_content;
@@ -111,7 +113,7 @@ fostlib::fs::path fostlib::join_paths(
         const fostlib::fs::path &root, const fostlib::fs::path &path) {
     if (path.empty()) {
         return root;
-    } else if (path.is_complete() || coerce<string>(path)[0] == '/') {
+    } else if (path.has_root_directory() || coerce<string>(path)[0] == '/') {
         return path;
     } else {
         return root / path;

--- a/Cpp/fost-core/file.cpp
+++ b/Cpp/fost-core/file.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2001-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2001-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -7,14 +7,13 @@
 
 
 #include "fost-core.hpp"
+#include <fost/filesystem.hpp>
 #include <fost/unicode.hpp>
 #include <fost/detail/utility.hpp>
 
 #include <fost/exception/file_error.hpp>
 #include <fost/exception/unexpected_eof.hpp>
 #include <fost/exception/unicode_encoding.hpp>
-
-#include <boost/filesystem/fstream.hpp>
 
 
 using namespace fostlib;

--- a/Cpp/fost-core/filesystem-path.tests.cpp
+++ b/Cpp/fost-core/filesystem-path.tests.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2009-2015, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2009-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -14,14 +14,14 @@ FSL_TEST_SUITE(boost_filesystem_path);
 
 
 FSL_TEST_FUNCTION(coercion_string) {
-    boost::filesystem::path p(L"somefilepath");
+    fostlib::fs::path p(L"somefilepath");
     FSL_CHECK_EQ(fostlib::coerce<fostlib::string>(p), L"somefilepath");
 }
 
 
 FSL_TEST_FUNCTION(coercion_json) {
-    boost::filesystem::path p(L"somefilepath");
+    fostlib::fs::path p(L"somefilepath");
     fostlib::json j(L"somefilepath");
     FSL_CHECK_EQ(fostlib::coerce<fostlib::json>(p), j);
-    FSL_CHECK_EQ(fostlib::coerce<boost::filesystem::path>(j), p);
+    FSL_CHECK_EQ(fostlib::coerce<fostlib::fs::path>(j), p);
 }

--- a/Cpp/fost-core/progress-tests.cpp
+++ b/Cpp/fost-core/progress-tests.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2013-2015, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2013-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -59,10 +59,10 @@ FSL_TEST_FUNCTION(meter_in_same_thread) {
 
 // FSL_TEST_FUNCTION( file_processing_progress ) {
 //     FSL_CHECK_EXCEPTION(
-//         fostlib::progress p1(boost::filesystem::path(L"Not-a-file.txt")),
+//         fostlib::progress p1(fostlib::fs::path(L"Not-a-file.txt")),
 //         fostlib::exceptions::file_error&);
 //
-//     fostlib::progress p2(boost::filesystem::path(
+//     fostlib::progress p2(fostlib::fs::path(
 //         L"../fost-base/LICENSE_1_0.txt"));
 //     fostlib::log::debug(fostlib::c_fost_base_core)
 //         ("p2.total", p2.total());

--- a/Cpp/fost-core/progress.cpp
+++ b/Cpp/fost-core/progress.cpp
@@ -41,7 +41,7 @@ fostlib::progress::progress(const fostlib::fs::path &file)
         int64_t bytes(coerce<int64_t>(fostlib::fs::file_size(file)));
         last = bytes;
         insert(meta, "stat", "size", "bytes", bytes);
-        std::time_t modified(fostlib::fs::last_write_time(file));
+        std::time_t modified(fostlib::last_write_time_as_time_t(file));
         insert(meta, "stat", "modified",
                timestamp(boost::posix_time::from_time_t(modified)));
     } catch (fostlib::fs::filesystem_error &e) {

--- a/Cpp/fost-core/progress.cpp
+++ b/Cpp/fost-core/progress.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2013-2018, Felspar Co Ltd. <https://support.felspar.com/>
+    Copyright 2013-2019, Felspar Co Ltd. <https://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -34,17 +34,17 @@ fostlib::progress::progress(const json &meta, work_amount upto)
 }
 
 
-fostlib::progress::progress(const boost::filesystem::path &file)
+fostlib::progress::progress(const fostlib::fs::path &file)
 : now(), next_send(timestamp::now()) {
     insert(meta, "filename", file);
     try {
-        int64_t bytes(coerce<int64_t>(boost::filesystem::file_size(file)));
+        int64_t bytes(coerce<int64_t>(fostlib::fs::file_size(file)));
         last = bytes;
         insert(meta, "stat", "size", "bytes", bytes);
-        std::time_t modified(boost::filesystem::last_write_time(file));
+        std::time_t modified(fostlib::fs::last_write_time(file));
         insert(meta, "stat", "modified",
                timestamp(boost::posix_time::from_time_t(modified)));
-    } catch (boost::filesystem::filesystem_error &e) {
+    } catch (fostlib::fs::filesystem_error &e) {
         throw fostlib::exceptions::file_error(e.what(), coerce<string>(file));
     }
     init();

--- a/Cpp/fost-core/setting.cpp
+++ b/Cpp/fost-core/setting.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2007-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2007-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -220,20 +220,19 @@ fostlib::settings::settings(const string &domain, const json &values) {
 }
 
 
-fostlib::settings::settings(const boost::filesystem::path &file) {
+fostlib::settings::settings(const fostlib::fs::path &file) {
     load_settings(coerce<string>(file), file);
 }
 
 
 fostlib::settings::settings(const setting<string> &json_file) {
     load_settings(
-            json_file.value(),
-            coerce<boost::filesystem::path>(json_file.value()));
+            json_file.value(), coerce<fostlib::fs::path>(json_file.value()));
 }
 
 
 void fostlib::settings::load_settings(
-        const string &domain, const boost::filesystem::path &filename) {
+        const string &domain, const fostlib::fs::path &filename) {
     load_settings(
             domain,
             fostlib::json::parse(fostlib::utf::load_file(filename, "{}")));

--- a/Cpp/fost-core/setting.cpp
+++ b/Cpp/fost-core/setting.cpp
@@ -246,9 +246,9 @@ void fostlib::settings::load_settings(const string &domain, const json &values) 
                 for (json::const_iterator name(section->begin());
                      name != section->end(); ++name) {
                     m_settings.push_back(
-                            boost::shared_ptr<setting<json>>(new setting<json>(
+                            std::make_unique<setting<json>>(
                                     domain, coerce<string>(section.key()),
-                                    coerce<string>(name.key()), *name)));
+                                    coerce<string>(name.key()), *name));
                 }
             }
         }

--- a/Cpp/fost-crypto/digester.cpp
+++ b/Cpp/fost-crypto/digester.cpp
@@ -113,7 +113,7 @@ fostlib::digester &fostlib::digester::
         operator<<(const fostlib::fs::path &filename) {
     fostlib::digester::impl::check(m_implementation.get());
     fostlib::progress progress(filename);
-    fostlib::fs::ifstream file(filename, std::ios::binary);
+    fostlib::ifstream file(filename, std::ios::binary);
     while (!file.eof() && file.good()) {
         boost::array<char, 4096> buffer;
         file.read(buffer.c_array(), buffer.size());

--- a/Cpp/fost-crypto/digester.cpp
+++ b/Cpp/fost-crypto/digester.cpp
@@ -110,10 +110,10 @@ fostlib::digester &fostlib::digester::operator<<(const fostlib::string &s) {
 
 
 fostlib::digester &fostlib::digester::
-        operator<<(const boost::filesystem::path &filename) {
+        operator<<(const fostlib::fs::path &filename) {
     fostlib::digester::impl::check(m_implementation.get());
     fostlib::progress progress(filename);
-    boost::filesystem::ifstream file(filename, std::ios::binary);
+    fostlib::fs::ifstream file(filename, std::ios::binary);
     while (!file.eof() && file.good()) {
         boost::array<char, 4096> buffer;
         file.read(buffer.c_array(), buffer.size());

--- a/Cpp/fost-crypto/digester.cpp
+++ b/Cpp/fost-crypto/digester.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2009-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2009-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -13,7 +13,7 @@
 #include <fost/crypto.hpp>
 
 #include <fstream>
-#include <boost/filesystem/fstream.hpp>
+#include <fost/filesystem.hpp>
 
 #define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
 #include <crypto++/md5.h>

--- a/Cpp/fost-crypto/signature.cpp
+++ b/Cpp/fost-crypto/signature.cpp
@@ -127,8 +127,8 @@ fostlib::hmac &fostlib::hmac::operator<<(f5::u8view d8) {
     return (*this) << const_memory_block(d8.data(), d8.data() + d8.bytes());
 }
 
-fostlib::hmac &fostlib::hmac::operator<<(const boost::filesystem::path &) {
+fostlib::hmac &fostlib::hmac::operator<<(const fostlib::fs::path &) {
     throw fostlib::exceptions::not_implemented(
-            "fostlib::hmac::operator << ( const boost::filesystem::path "
+            "fostlib::hmac::operator << ( const fostlib::fs::path "
             "&filename )");
 }

--- a/Cpp/fost-sinks/panoptes.cpp
+++ b/Cpp/fost-sinks/panoptes.cpp
@@ -26,7 +26,7 @@ bool fostlib::log::panoptes::operator()(const fostlib::log::message &m) {
             fostlib::json::unparse(fostlib::coerce<fostlib::json>(m), false));
     const auto *modp = &m.module();
 
-    boost::filesystem::wpath filename;
+    fostlib::fs::path filename;
     auto archive = logfile_pathnames.find(modp);
     if (archive == logfile_pathnames.end()) {
         filename =
@@ -36,7 +36,7 @@ bool fostlib::log::panoptes::operator()(const fostlib::log::message &m) {
         filename = (archive->second)(m.when());
     }
 
-    boost::filesystem::ofstream file(
+    fostlib::fs::ofstream file(
             filename, std::ios_base::out | std::ios_base::app);
     file << entry.c_str() << std::endl;
 

--- a/Cpp/fost-sinks/panoptes.cpp
+++ b/Cpp/fost-sinks/panoptes.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2016-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2016-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Copyright 2012-2015, Proteus Technologies Co. Ltd.
 
@@ -8,8 +8,8 @@
 */
 
 
+#include <fost/filesystem.hpp>
 #include <fost/sinks.panoptes.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 
 namespace {

--- a/Cpp/fost-sinks/panoptes.pathname.cpp
+++ b/Cpp/fost-sinks/panoptes.pathname.cpp
@@ -1,9 +1,10 @@
-/*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2016-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Copyright 2012-2015, Proteus Technologies Co. Ltd.
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -27,16 +28,16 @@ fostlib::log::detail::archive_pathname::fileloc_type
         fostlib::log::detail::archive_pathname::pathname(
                 const fostlib::timestamp &when) const {
     fostlib::string ts = fostlib::replace_all(coerce<string>(when), ":", null);
-    boost::filesystem::wpath directory =
-            coerce<boost::filesystem::wpath>(c_log_sink_file_root.value())
-            / coerce<boost::filesystem::wpath>(ts.substr(0, 7))
-            / coerce<boost::filesystem::wpath>(ts.substr(8, 2));
-    boost::filesystem::wpath data_path(
+    fostlib::fs::wpath directory =
+            coerce<fostlib::fs::wpath>(c_log_sink_file_root.value())
+            / coerce<fostlib::fs::wpath>(ts.substr(0, 7))
+            / coerce<fostlib::fs::wpath>(ts.substr(8, 2));
+    fostlib::fs::wpath data_path(
             directory
-            / coerce<boost::filesystem::wpath>(
+            / coerce<fostlib::fs::wpath>(
                       modulep->as_string() + "/" + ts + ".jsonl"));
-    if (!boost::filesystem::exists(data_path.parent_path())) {
-        boost::filesystem::create_directories(data_path.parent_path());
+    if (!fostlib::fs::exists(data_path.parent_path())) {
+        fostlib::fs::create_directories(data_path.parent_path());
     }
     date day(coerce<boost::posix_time::ptime>(when).date());
     fileloc_type fl = {day, data_path};
@@ -44,14 +45,14 @@ fostlib::log::detail::archive_pathname::fileloc_type
 }
 
 
-boost::filesystem::wpath fostlib::log::detail::archive_pathname::
+fostlib::fs::wpath fostlib::log::detail::archive_pathname::
         operator()(const fostlib::timestamp &when) {
     const boost::posix_time::ptime time(coerce<boost::posix_time::ptime>(when));
     const date day(time.date());
     if (not fileloc) {
         fileloc = pathname(when);
-    } else if (boost::filesystem::exists(fileloc.value().pathname)) {
-        uintmax_t size = boost::filesystem::file_size(fileloc.value().pathname);
+    } else if (fostlib::fs::exists(fileloc.value().pathname)) {
+        uintmax_t size = fostlib::fs::file_size(fileloc.value().pathname);
         if (rotate(size) || day != fileloc.value().date) {
             fileloc = pathname(when);
         }

--- a/Cpp/fost-sinks/panoptes.pathname.tests.cpp
+++ b/Cpp/fost-sinks/panoptes.pathname.tests.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2016-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2016-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Copyright 2012-2015, Proteus Technologies Co. Ltd.
 
@@ -28,14 +28,14 @@ FSL_TEST_FUNCTION(filename) {
 
     FSL_CHECK_EQ(
             filename(w),
-            fostlib::coerce<boost::filesystem::path>(
+            fostlib::coerce<fostlib::fs::path>(
                     fostlib::c_log_sink_file_root.value()
                     + "/2011-08/15/--unknown"
                       "/2011-08-15T145400Z.jsonl"));
 
     FSL_CHECK_EQ(
             module(w),
-            fostlib::coerce<boost::filesystem::path>(
+            fostlib::coerce<fostlib::fs::path>(
                     fostlib::c_log_sink_file_root.value()
                     + "/2011-08/15/fost/sinks/test/" __FILE__
                       "/2011-08-15T145400Z.jsonl"));

--- a/Cpp/include/fost/crypto.hpp
+++ b/Cpp/include/fost/crypto.hpp
@@ -98,7 +98,7 @@ namespace fostlib {
                 return *this;
         }
         digester &operator<<(const string &str);
-        digester &operator<<(const boost::filesystem::path &filename);
+        digester &operator<<(const fostlib::fs::path &filename);
 
         std::vector<unsigned char> digest() const;
 
@@ -145,7 +145,7 @@ namespace fostlib {
             return *this << fostlib::utf8_string(n);
         }
         hmac &operator<<(f5::u8view);
-        hmac &operator<<(const boost::filesystem::path &filename);
+        hmac &operator<<(const fostlib::fs::path &filename);
 
         std::vector<unsigned char> digest() const;
 

--- a/Cpp/include/fost/crypto.hpp
+++ b/Cpp/include/fost/crypto.hpp
@@ -12,8 +12,8 @@
 
 
 #include <fost/array>
+#include <fost/filesystem.hpp>
 #include <fost/pointers>
-#include <boost/filesystem.hpp>
 
 // TODO Older libc6-dev packages don't provide this header :(
 // This needs to be fixed using C++17's `__has_include`

--- a/Cpp/include/fost/detail/coerce.hpp
+++ b/Cpp/include/fost/detail/coerce.hpp
@@ -11,8 +11,7 @@
 
 #include <fost/coerce.hpp>
 #include <fost/exception.hpp>
-
-#include <boost/system/error_code.hpp>
+#include <fost/filesystem.hpp>
 
 #include <sstream>
 
@@ -25,8 +24,8 @@ namespace fostlib {
 
     /// Convert a Boost error to JSON
     template<>
-    struct coercer<json, boost::system::error_code> {
-        json coerce(const boost::system::error_code &e) {
+    struct coercer<json, fostlib::error_code> {
+        json coerce(const fostlib::error_code &e) {
             return json(e.message().c_str());
         }
     };

--- a/Cpp/include/fost/exception/file_error.hpp
+++ b/Cpp/include/fost/exception/file_error.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright  2001-2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright  2001-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -28,8 +28,8 @@ namespace fostlib {
             /// Thow an error from an error code
             file_error(
                     const string &message,
-                    const boost::filesystem::path &,
-                    boost::system::error_code) noexcept;
+                    const fostlib::fs::path &,
+                    fostlib::error_code) noexcept;
 
           protected:
             const wchar_t *const message() const noexcept;

--- a/Cpp/include/fost/exception/not_implemented.hpp
+++ b/Cpp/include/fost/exception/not_implemented.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2001-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2001-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -11,6 +11,7 @@
 
 #include <fost/coerce.hpp>
 #include <fost/exception.hpp>
+#include <fost/filesystem.hpp>
 
 
 namespace fostlib {
@@ -48,15 +49,15 @@ namespace fostlib {
                     const E &extra)
             : not_implemented(function, message, coerce<json>(extra)) {}
             /// Allow us to throw from a Boost error code
-            not_implemented(nliteral m, boost::system::error_code e) noexcept
+            not_implemented(nliteral m, fostlib::error_code e) noexcept
             : not_implemented{f5::u8view{m, std::strlen(m)}, e} {}
             not_implemented(
                     const string &function,
-                    boost::system::error_code error) noexcept;
+                    fostlib::error_code error) noexcept;
             /// Allow us to throw from a Boost error code with a message
             not_implemented(
                     const string &function,
-                    boost::system::error_code error,
+                    fostlib::error_code error,
                     const string &message) noexcept;
 
           protected:

--- a/Cpp/include/fost/exception/unexpected_eof.hpp
+++ b/Cpp/include/fost/exception/unexpected_eof.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright  2001-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright  2001-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -27,7 +27,7 @@ namespace fostlib {
             unexpected_eof(
                     const string &message, const string &filename) noexcept;
             unexpected_eof(
-                    const string &message, boost::system::error_code) noexcept;
+                    const string &message, fostlib::error_code) noexcept;
 
           protected:
             const wchar_t *const message() const noexcept;

--- a/Cpp/include/fost/file.hpp
+++ b/Cpp/include/fost/file.hpp
@@ -22,65 +22,63 @@ namespace fostlib {
 
 
         /// Load a text file which is UTF-8 encoded
-        FOST_CORE_DECLSPEC string
-                load_file(const boost::filesystem::path &filename);
+        FOST_CORE_DECLSPEC string load_file(const fostlib::fs::path &filename);
         /// Load a text file which is UTF-8 encoded, giving default content to
         /// use if there is an error
         FOST_CORE_DECLSPEC string load_file(
-                const boost::filesystem::path &filename,
+                const fostlib::fs::path &filename,
                 const string &default_content);
 
         /// Save a string into a file UTF-8 encoded
         FOST_CORE_DECLSPEC void save_file(
-                const boost::filesystem::path &filename, const string &content);
+                const fostlib::fs::path &filename, const string &content);
 
 
     }
 
 
-    typedef boost::filesystem::directory_iterator directory_iterator;
+    typedef fostlib::fs::directory_iterator directory_iterator;
 
 
     /// Coerce a string to a file path
     template<>
-    struct coercer<boost::filesystem::path, string> {
-        boost::filesystem::path coerce(const string &s) {
+    struct coercer<fostlib::fs::path, string> {
+        fostlib::fs::path coerce(const string &s) {
             return static_cast<std::string>(s);
         }
     };
     /// Coerce a file path to a string
     template<>
-    struct coercer<string, boost::filesystem::path> {
-        string coerce(const boost::filesystem::path &p) {
+    struct coercer<string, fostlib::fs::path> {
+        string coerce(const fostlib::fs::path &p) {
             return fostlib::coerce<string>(p.wstring());
         }
     };
     /// Coerce a file path to JSON
     template<>
-    struct coercer<json, boost::filesystem::path> {
-        json coerce(const boost::filesystem::path &p) {
+    struct coercer<json, fostlib::fs::path> {
+        json coerce(const fostlib::fs::path &p) {
             return json(fostlib::coerce<string>(p));
         }
     };
     /// Coerce JSON to a file path
     template<>
-    struct coercer<boost::filesystem::path, fostlib::json> {
-        boost::filesystem::path coerce(const json &j) {
-            return fostlib::coerce<boost::filesystem::path>(
+    struct coercer<fostlib::fs::path, fostlib::json> {
+        fostlib::fs::path coerce(const json &j) {
+            return fostlib::coerce<fostlib::fs::path>(
                     fostlib::coerce<string>(j));
         }
     };
 
 
     /// Return a path unique pathname
-    FOST_CORE_DECLSPEC boost::filesystem::path unique_filename();
+    FOST_CORE_DECLSPEC fostlib::fs::path unique_filename();
 
 
     /// Join two paths. If path is rooted it is returned, otherwise it is joined
     /// to root
-    FOST_CORE_DECLSPEC boost::filesystem::path join_paths(
-            const boost::filesystem::path &root,
-            const boost::filesystem::path &path);
+    FOST_CORE_DECLSPEC fostlib::fs::path join_paths(
+            const fostlib::fs::path &root, const fostlib::fs::path &path);
 
 
 }
@@ -91,7 +89,7 @@ namespace std {
 
     /// Allow a path to be printed to an ostream
     inline fostlib::ostream &
-            operator<<(fostlib::ostream &o, const boost::filesystem::path &p) {
+            operator<<(fostlib::ostream &o, const fostlib::fs::path &p) {
         return o << fostlib::coerce<fostlib::string>(p);
     }
 

--- a/Cpp/include/fost/file.hpp
+++ b/Cpp/include/fost/file.hpp
@@ -12,7 +12,7 @@
 
 
 #include <fost/string-fwd.hpp>
-#include <boost/filesystem.hpp>
+#include <fost/filesystem.hpp>
 
 
 namespace fostlib {

--- a/Cpp/include/fost/filesystem.hpp
+++ b/Cpp/include/fost/filesystem.hpp
@@ -20,4 +20,3 @@ namespace fostlib {
 
 
 }
-

--- a/Cpp/include/fost/filesystem.hpp
+++ b/Cpp/include/fost/filesystem.hpp
@@ -9,6 +9,32 @@
 #pragma once
 
 
+#ifdef FSL_FORCE_STD_FILESYSTEM
+
+
+#include <filesystem>
+
+
+namespace fostlib {
+
+
+    namespace fs = std::filesystem;
+    using error_code = std::error_code;
+    using ifstream = std::ifstream;
+    using ofstream = std::ofstream;
+
+    inline auto last_write_time_as_time_t(const std::filesystem::path &p) {
+        auto const ftime = std::filesystem::last_write_time(p);
+        return decltype(ftime)::clock::to_time_t(ftime);
+    }
+
+
+}
+
+
+#else
+
+
 #include <boost/filesystem.hpp>
 
 
@@ -17,6 +43,15 @@ namespace fostlib {
 
     namespace fs = boost::filesystem;
     using error_code = boost::system::error_code;
+    using ifstream = boost::filesystem::ifstream;
+    using ofstream = boost::filesystem::ofstream;
+
+    inline auto last_write_time_as_time_t(const boost::filesystem::path &p) {
+        return fs::last_write_time(p);
+    }
 
 
 }
+
+
+#endif

--- a/Cpp/include/fost/filesystem.hpp
+++ b/Cpp/include/fost/filesystem.hpp
@@ -1,0 +1,22 @@
+/**
+    Copyright 2019, Felspar Co Ltd. <https://support.felspar.com/>
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+*/
+
+
+#pragma once
+
+
+#include <boost/filesystem.hpp>
+
+
+namespace fostlib {
+
+
+    namespace fs = boost::filesystem;
+
+
+}
+

--- a/Cpp/include/fost/filesystem.hpp
+++ b/Cpp/include/fost/filesystem.hpp
@@ -16,6 +16,7 @@ namespace fostlib {
 
 
     namespace fs = boost::filesystem;
+    using error_code = boost::system::error_code;
 
 
 }

--- a/Cpp/include/fost/progress.hpp
+++ b/Cpp/include/fost/progress.hpp
@@ -151,7 +151,7 @@ namespace fostlib {
         progress(const json &meta, work_amount upto);
 
         /// Progress recording for a file content
-        progress(const boost::filesystem::path &file);
+        progress(const fostlib::fs::path &file);
 
         /// Allow tracking of removal of progress recorders. Not virtual as
         /// we're not going to sub-class this

--- a/Cpp/include/fost/progress.hpp
+++ b/Cpp/include/fost/progress.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2013-2018, Felspar Co Ltd. <https://support.felspar.com/>
+    Copyright 2013-2019, Felspar Co Ltd. <https://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -11,10 +11,9 @@
 #pragma once
 
 
+#include <fost/filesystem.hpp>
 #include <fost/timestamp.hpp>
 #include <fost/thread.hpp>
-
-#include <boost/filesystem.hpp>
 
 #include <set>
 

--- a/Cpp/include/fost/settings.hpp
+++ b/Cpp/include/fost/settings.hpp
@@ -138,8 +138,7 @@ namespace fostlib {
     /// Store a number of settings read from the passed in JSON blob
     class FOST_CORE_DECLSPEC settings {
         std::list<boost::shared_ptr<setting<json>>> m_settings;
-        void load_settings(
-                const string &domain, const boost::filesystem::path &);
+        void load_settings(const string &domain, const fostlib::fs::path &);
         void load_settings(const string &domain, const json &);
 
       public:
@@ -148,7 +147,7 @@ namespace fostlib {
         /// Construct the settings given a JSON file in the specified setting
         settings(const setting<string> &);
         /// Construct the settings given a filename containing JSON
-        settings(const boost::filesystem::path &);
+        settings(const fostlib::fs::path &);
     };
 
 

--- a/Cpp/include/fost/settings.hpp
+++ b/Cpp/include/fost/settings.hpp
@@ -13,7 +13,7 @@
 
 #include <fost/json.hpp>
 #include <fost/accessors.hpp>
-#include <boost/filesystem.hpp>
+#include <fost/filesystem.hpp>
 
 
 namespace fostlib {

--- a/Cpp/include/fost/settings.hpp
+++ b/Cpp/include/fost/settings.hpp
@@ -137,7 +137,7 @@ namespace fostlib {
 
     /// Store a number of settings read from the passed in JSON blob
     class FOST_CORE_DECLSPEC settings {
-        std::list<boost::shared_ptr<setting<json>>> m_settings;
+        std::vector<std::unique_ptr<setting<json>>> m_settings;
         void load_settings(const string &domain, const fostlib::fs::path &);
         void load_settings(const string &domain, const json &);
 

--- a/Cpp/include/fost/sinks.panoptes.hpp
+++ b/Cpp/include/fost/sinks.panoptes.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2016-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -25,7 +25,7 @@ namespace fostlib {
             /// The file name for the specified log file
             class archive_pathname {
                 /// Folder we save the log files into
-                boost::filesystem::wpath logfile_directory;
+                fostlib::fs::path logfile_directory;
                 /// The module part of the file name
                 const module *modulep;
                 /// The file size (beyond which) we will rotate the log files
@@ -34,7 +34,7 @@ namespace fostlib {
                 /// Structure for storing information about the current logfile
                 struct fileloc_type {
                     fostlib::date date;
-                    boost::filesystem::wpath pathname;
+                    fostlib::fs::path pathname;
                 };
                 /// The current log file name and its date
                 fostlib::nullable<fileloc_type> fileloc;
@@ -54,7 +54,7 @@ namespace fostlib {
                 const fostlib::jcursor &meta_db_path() const;
 
                 /// Return the file name for the given timestamp
-                boost::filesystem::wpath operator()(const fostlib::timestamp &);
+                fostlib::fs::path operator()(const fostlib::timestamp &);
 
                 /// Return true if the file needs to be rotated
                 bool rotate(uintmax_t);

--- a/Cpp/include/fost/timestamp.hpp
+++ b/Cpp/include/fost/timestamp.hpp
@@ -176,11 +176,10 @@ namespace fostlib {
 
     /// Get a format suitable for use in file names
     template<>
-    struct coercer<boost::filesystem::path, timestamp> {
-        boost::filesystem::path coerce(const timestamp &ts) {
+    struct coercer<fostlib::fs::path, timestamp> {
+        fostlib::fs::path coerce(const timestamp &ts) {
             string s(fostlib::coerce<string>(ts));
-            return fostlib::coerce<boost::filesystem::path>(
-                    replace_all(s, ":"));
+            return fostlib::coerce<fostlib::fs::path>(replace_all(s, ":"));
         }
     };
 

--- a/Examples/ftest/ftest.cpp
+++ b/Examples/ftest/ftest.cpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2005-2010, Felspar Co Ltd. http://fost.3.felspar.com/
+/**
+    Copyright 2005-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -30,8 +30,8 @@ FSL_MAIN(
     else {
         std::list<boost::shared_ptr<fostlib::dynlib>> libraries;
         for (fostlib::arguments::size_type i(1); i < args.size(); ++i) {
-            boost::filesystem::wpath extension =
-                    fostlib::coerce<boost::filesystem::wpath>(args[i].value())
+            fostlib::fs::path extension =
+                    fostlib::coerce<fostlib::fs::path>(args[i].value())
                             .extension();
             if (extension != L".lib" && extension != L".pdb")
                 libraries.push_back(boost::shared_ptr<fostlib::dynlib>(

--- a/Examples/hash/hash.cpp
+++ b/Examples/hash/hash.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2013-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2013-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -25,7 +25,7 @@ using namespace fostlib;
 
 
 namespace {
-    string hash(meter &, const boost::filesystem::path &file) {
+    string hash(meter &, const fostlib::fs::path &file) {
         digester hasher(md5);
         hasher << file;
         return coerce<string>(coerce<hex_string>(hasher.digest()));
@@ -35,8 +35,8 @@ namespace {
             process(ostream &out,
                     meter &tracking,
                     workerpool &pool,
-                    const boost::filesystem::path path) {
-        if (boost::filesystem::is_directory(path)) {
+                    const fostlib::fs::path path) {
+        if (fostlib::fs::is_directory(path)) {
             for (directory_iterator file(path); file != directory_iterator();
                  ++file) {
                 process(out, tracking, pool, *file);
@@ -62,7 +62,7 @@ FSL_MAIN(L"hash", L"File hashing")(ostream &out, arguments &args) {
     meter tracking;
     workerpool pool;
     for (std::size_t n(1); n < args.size(); ++n) {
-        auto path(coerce<boost::filesystem::path>(args[n].value()));
+        auto path(coerce<fostlib::fs::path>(args[n].value()));
         process(out, tracking, pool, path);
     }
     return 0;


### PR DESCRIPTION
This allows, but doesn't force, the switch from Boost filesystem to `std::filesystem`. Once this lands we can change the other libraries to use the new `fostlib::fs` namespace and at some point in the future we'll make this the default.
 