### PR TITLE
Test files folder

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-04-25  Kirit Saelensminde  <kirit@felspar.com>
+ Add a setting, `fostlib::test::c_files_folder`, describing the root folder tests should use if they need access to the file system.
+
 2019-04-02  Kirit Saelensminde  <kirit@felspar.com>
  Use of define `FSL_FORCE_STD_FILESYSTEM` switches from `boost::filesystem` to `std::filesystem` with names in `fostlib::fs`.
 

--- a/Cpp/fost-test/testsuite.cpp
+++ b/Cpp/fost-test/testsuite.cpp
@@ -22,6 +22,13 @@ using namespace fostlib;
 const module fostlib::c_fost_base_test(c_fost_base, "test");
 
 
+fostlib::setting<fostlib::string> const fostlib::test::c_files_folder(
+        "fost-test/testsuite.cpp",
+        "Tests",
+        "Test file folder",
+        fostlib::coerce<fostlib::string>(fostlib::unique_filename()),
+        true);
+
 fostlib::setting<bool> const fostlib::test::c_output_verbose(
         "fost-test/testsuite.cpp", "Tests", "Display test names", false, true);
 fostlib::setting<bool> const fostlib::test::c_output_continue(

--- a/Cpp/fost-test/testsuite.cpp
+++ b/Cpp/fost-test/testsuite.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2007-2018, Felspar Co Ltd. <http://support.felspar.com/>
+    Copyright 2007-2019, Felspar Co Ltd. <http://support.felspar.com/>
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -22,6 +22,14 @@ using namespace fostlib;
 const module fostlib::c_fost_base_test(c_fost_base, "test");
 
 
+fostlib::setting<bool> const fostlib::test::c_output_verbose(
+        "fost-test/testsuite.cpp", "Tests", "Display test names", false, true);
+fostlib::setting<bool> const fostlib::test::c_output_continue(
+        "fost-test/testsuite.cpp", "Tests", "Continue after error", true, true);
+fostlib::setting<double> const fostlib::test::c_output_warning_test_duration(
+        "fost-test/testsuite.cpp", "Tests", "Warning test duration", 10.0, true);
+
+
 namespace {
 
 
@@ -30,26 +38,6 @@ namespace {
         static suite_t s;
         return s;
     }
-
-
-    setting<bool> c_verbose(
-            L"fost-test/testsuite.cpp",
-            L"Tests",
-            L"Display test names",
-            false,
-            true);
-    setting<bool> c_continue(
-            L"fost-test/testsuite.cpp",
-            L"Tests",
-            L"Continue after error",
-            true,
-            true);
-    setting<double> c_warning_test_duration(
-            L"fost-test/testsuite.cpp",
-            L"Tests",
-            L"Warning test duration",
-            10.0,
-            true);
 
 
 }
@@ -117,7 +105,7 @@ namespace {
                     fostlib::test::suite::test_keys_type testnames(
                             suite->test_keys());
                     for (auto &&tn : testnames) {
-                        if (op && c_verbose.value())
+                        if (op && fostlib::test::c_output_verbose.value())
                             *op << sn << L": " << tn << '\n';
                         auto tests(suite->tests(tn));
                         for (auto &&test : tests) {
@@ -130,7 +118,9 @@ namespace {
                                 const timer started;
                                 test->execute();
                                 const double elapsed = started.seconds();
-                                if (elapsed > c_warning_test_duration.value())
+                                if (elapsed
+                                    > fostlib::test::c_output_warning_test_duration
+                                              .value())
                                     fostlib::log::warning(
                                             c_fost_base_test,
                                             "Test " + sn + "--" + tn + " took "
@@ -154,7 +144,7 @@ namespace {
                 insert(e.data(), "test", "suite", sn);
                 if (op) {
                     *op << e << std::endl;
-                } else if (not c_continue.value()) {
+                } else if (not fostlib::test::c_output_continue.value()) {
                     throw;
                 }
             }

--- a/Cpp/include/fost/test.hpp
+++ b/Cpp/include/fost/test.hpp
@@ -41,6 +41,12 @@ namespace fostlib {
     namespace test {
 
 
+        /// Location that tests can use on the filesystem for writing
+        /// and loading files from. Individual tests should use their own
+        /// folder within this to ensure that they don't interfere with
+        /// other tests.
+        extern setting<string> const c_files_folder;
+
         /// Control verbosity of test output
         extern setting<bool> const c_output_verbose;
         /// Whether the test run should continue after a failure

--- a/Cpp/include/fost/test.hpp
+++ b/Cpp/include/fost/test.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2007-2017, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2007-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -39,6 +39,15 @@ namespace fostlib {
 
 
     namespace test {
+
+
+        /// Control verbosity of test output
+        extern setting<bool> const c_output_verbose;
+        /// Whether the test run should continue after a failure
+        extern setting<bool> const c_output_continue;
+        /// The time before a warning is generated for a long running
+        /// test
+        extern setting<double> const c_output_warning_test_duration;
 
 
         class test;


### PR DESCRIPTION
Adds a setting for the folder tests are expected to use for writing and reading files.

This is needed because Android doesn't give the process permission to write to the temp files folder.