### PR TITLE
Minit always executes its sub-process

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-07-01  Kirit Saelensminde  <kirit@felspar.com>
+ `minit` will now always try to execute, even if it is not needed.
+
 2019-05-12  Kirit Saelensminde  <kirit@felspar.com>
  * Deprecate `length` members of `tagged_string` and `string`.
  * Add some APIs to `tagged_string` that are currently on `string`.
@@ -7,7 +10,7 @@
 
 2019-04-25  Kirit Saelensminde  <kirit@felspar.com>
  Deprecate `string::length` and `tagged_string<>::length`
- 
+
 2019-04-25  Kirit Saelensminde  <kirit@felspar.com>
  Add a setting, `fostlib::test::c_files_folder`, describing the root folder tests should use if they need access to the file system.
 

--- a/Cpp/minit/minit.c
+++ b/Cpp/minit/minit.c
@@ -51,8 +51,10 @@ int main(int argc, char *argv[], char *env[]) {
     int status, child;
 
     if (getpid() != 1) {
-        printf("Not running as PID 1. No need to use minit\n");
-        return 1;
+        printf("Minit is not needed, but launching process anyway...");
+        execvpe(argv[1], argv + 1, env);
+        printf("execvpe failed\n");
+        exit(255);
     } else if ( argc < 2 ) {
         printf("Must supply a program for minit to execute\n");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
If we aren't pid 1 then we should just `execvpe` the desired program.